### PR TITLE
Support DESTDIR + improvements for easy packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,16 @@ all:
 
 INSTALL_PATH=/usr/local/bin
 install:
-	install auto-disper ${INSTALL_PATH}
-	install -m 755 autorandr ${INSTALL_PATH}
-	install -m 644 bash_completion/autorandr /etc/bash_completion.d/
+	install -D auto-disper ${DESTDIR}${INSTALL_PATH}/auto-disper
+	install -D -m 755 autorandr ${DESTDIR}${INSTALL_PATH}/autorandr
+	install -D -m 644 bash_completion/autorandr ${DESTDIR}/etc/bash_completion.d/autorandr
 
 hotplug:
-	install -m 755 pm-utils/40autorandr /etc/pm/sleep.d/
-	install -m 644 udev/40-monitor-hotplug.rules /etc/udev/rules.d/
+	install -D -m 755 pm-utils/40autorandr ${DESTDIR}/etc/pm/sleep.d/40autorandr
+	install -D -m 644 udev/40-monitor-hotplug.rules ${DESTDIR}/etc/udev/rules.d/40-monitor-hotplug.rules
+ifeq (${USER},root)
 	udevadm control --reload-rules
+else
+	@echo "Please run this command as root:"
+	@echo "    udevadm control --reload-rules"
+endif


### PR DESCRIPTION
These changes make it possible to easily create distribution packages without modifying the source.
A package maintainer only has to figure out which parts to put in a post-install script (e.g. udevadm control --reload-rules).
