### PR TITLE
Fix rotated outputs mode detection

### DIFF
--- a/autorandr
+++ b/autorandr
@@ -135,7 +135,6 @@ current_cfg_xrandr() {
 		if (($4 == "left") || ($4 == "right")) {
 			split(A[1], B, "x");
 			A[1] = B[2]"x"B[1];
-			print "rotate "$4;
 		}
 		print "mode "A[1];
 		print "pos "A[2]"x"A[3];


### PR DESCRIPTION
This old patch fixes rotated outputs by swapping width and height from the xrandr output.
UPDATE: We are already printing out the "rotate" line. No reason to do that twice.
