### PR TITLE
Revert to general rotation detection

### DIFF
--- a/autorandr
+++ b/autorandr
@@ -141,6 +141,9 @@ current_cfg_xrandr() {
 		if ($4 !~ /^\(/) {
 			print "rotate "$4;
 		}
+		else {
+			print "rotate normal";
+		}
 		next;
 	}
 	# disconnected or disabled displays


### PR DESCRIPTION
Reverted previous changes, but re-added the "default to normal rotation" behaviour in a new place.
