### PR TITLE
Added a virtual profile named 'common'.

### DIFF
--- a/autorandr
+++ b/autorandr
@@ -307,7 +307,12 @@ load() {
 	local PROFILE="$1"
 	local CONF="$PROFILES/$PROFILE/config"
 	local IS_VIRTUAL_PROFILE=`echo "$RESERVED_PROFILE_NAMES" | grep -c "^ $PROFILE "`
-	[ -f "$CONF" -o -n $IS_VIRTUAL_PROFILE ] || return 1
+
+	if [ ! -f "$CONF" -a $IS_VIRTUAL_PROFILE == 0 ]; then
+		echo " -> Error: Profile '$PROFILE' does not exist." >&2
+		return
+	fi
+
 	if [ -x "$PROFILES/preswitch" ]; then
 		"$PROFILES/preswitch" "$PROFILE"
 	fi
@@ -317,7 +322,7 @@ load() {
 
 	if [ -f "$CONF" ]; then
 		echo " -> loading profile $PROFILE"
-		if [ -n $IS_VIRTUAL_PROFILE ]; then
+		if [ $IS_VIRTUAL_PROFILE != 0 ]; then
 			echo " -> Warning: Existing profile overrides virtual profile with same name" >&2
 		fi
 		$LOAD_METHOD "$CONF"


### PR DESCRIPTION
The virtual profile 'common' calculates the lowest (edit: **largest**) common resolution of all attached xrandr displays, and clones the desktop onto all.
I set this profile to my default one, so that at unknown monitors, especially projectors for presentations, things will just clone to the lowest common resolution. Any more specific profile (e.g. for my primary workstation) would then override the clone-to-all.
