### PR TITLE
Fix for python3 TypeError for 'dict_keys'

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -218,7 +218,7 @@ class XrandrOutput(object):
                 fuzzy_output = re.sub("(card[0-9]+|-)", "", options["output"])
                 if fuzzy_output not in fuzzy_edid_map:
                     raise RuntimeError("Failed to find a corresponding output in config/setup for output `%s'" % options["output"])
-                edid = edid_map[edid_map.keys()[fuzzy_edid_map.index(fuzzy_output)]]
+                edid = edid_map[list(edid_map.keys())[fuzzy_edid_map.index(fuzzy_output)]]
         output = options["output"]
         del options["output"]
 


### PR DESCRIPTION
TypeError: 'dict_keys' object does not support indexing

Explanation:
In python2x, edid_map.keys() returned a list.
With python3.x, it returns a dict_keys object, which behaves more like a set instead of list.

Inspired from:
http://stackoverflow.com/questions/17322668/xi-xj-xj-xi-typeerror-dict-keys-object-does-not-support-indexing

I tested this change with python2, and it seems to work.