### PR TITLE
Use XDG Base Directory Specification for config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To change this behaviour and switch to a fallback configuration, specify
 `--default <profile>`.
 
 Another script called `postswitch` can be placed in the directory
-`~/.autorandr` as well as in all profile directories: The scripts are executed
+`~/.config/autorandr` as well as in all profile directories: The scripts are executed
 after a mode switch has taken place and can notify window managers or other
 applications about it.
 

--- a/autorandr
+++ b/autorandr
@@ -29,8 +29,8 @@
 
 XRANDR=/usr/bin/xrandr
 DISPER=/usr/bin/disper
-PROFILES=~/.autorandr
-CONFIG=~/.autorandr.conf
+PROFILES=~/.config/autorandr/profiles
+CONFIG=~/.config/autorandr/config
 RESERVED_PROFILE_NAMES=`cat <<EOF
  common     Clone all connected outputs at the largest common resolution
  horizontal Stack all connected outputs horizontally at their largest resolution
@@ -355,7 +355,7 @@ Usage: $SCRIPTNAME [options]
  --default <profile>.
 
  Another script called "postswitch" can be placed in the directory
- ~/.autorandr as well as in any profile directories: The scripts are executed
+ ~/.config/autorandr as well as in any profile directories: The scripts are executed
  after a mode switch has taken place and can notify window managers. The same
  goes for "preswitch", which will be executed before a mode switch.
 

--- a/autorandr.py
+++ b/autorandr.py
@@ -459,7 +459,12 @@ def main(argv):
         print(str(e))
         options = { "--help": True }
 
-    profile_path = os.path.expanduser("~/.config/autorandr/profiles")
+
+    profile_dir = os.path.expanduser("~/.autorandr")
+    if not os.path.isdir(profile_dir):
+        profile_dir = os.path.join(os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")), "autorandr")
+    
+    profile_path = os.path.join(profile_dir, "profiles")
 
     try:
         profiles = load_profiles(profile_path)

--- a/autorandr.py
+++ b/autorandr.py
@@ -67,7 +67,7 @@ Usage: autorandr [options]
  --default <profile>.
 
  Another script called "postswitch "can be placed in the directory
- ~/.autorandr as well as in any profile directories: The scripts are executed
+ ~/.config/autorandr/profiles as well as in any profile directories: The scripts are executed
  after a mode switch has taken place and can notify window managers.
 
  The following virtual configurations are available:
@@ -459,7 +459,7 @@ def main(argv):
         print(str(e))
         options = { "--help": True }
 
-    profile_path = os.path.expanduser("~/.autorandr")
+    profile_path = os.path.expanduser("~/.config/autorandr/profiles")
 
     try:
         profiles = load_profiles(profile_path)

--- a/bash_completion/autorandr
+++ b/bash_completion/autorandr
@@ -10,8 +10,8 @@ _autorandr ()
 
 	opts="-h -c -s -l -d"
 	lopts="--help --change --save --load --default --force --fingerprint --config"
-	if [ -d ~/.autorandr ]; then
-		prfls="`find ~/.autorandr/* -maxdepth 1 -type d -printf '%f\n'`"
+	if [ -d ~/.config/autorandr/* ]; then
+		prfls="`find ~/.config/autorandr/* -maxdepth 1 -type d -printf '%f\n'`"
 	else
 		prfls=""
 	fi


### PR DESCRIPTION
It would be really nice if autorandr would not clutter my home directory.

I suggest respecting the [XDG Base Directory Specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) and move the configuration to `~/.config/autorandr`.

This PR should not be considered complete. 
A final implementaion should check for the `$XDG_CONFIG_HOME` environment variable and fallback to `$HOME/.config` if it's not defined.

Maybe there could be also a be `$AUTORANDR_CONFIG_HOME` env to overwrite the default behaviour and overwrite the config location entirely. 

Also a upgrade/migration from the old config location to the new one would be nice.

I am not really a python guy so before doing a complete implementation I am looking forward to get some opinions.

