### PR TITLE
fix infinite loop in debug_regexp

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -278,6 +278,8 @@ def debug_regexp(pattern, string):
         bounds = ( 0, len(string) )
         while bounds[0] != bounds[1]:
             half = int((bounds[0] + bounds[1]) / 2)
+            if half == bounds[0]:
+                break
             bounds = (half, bounds[1]) if regex.search(pattern, string[:half], partial=True) else (bounds[0], half - 1)
         partial_length = bounds[0]
         return ("Regular expression matched until position "


### PR DESCRIPTION
On issue #13 I was seeing an infinite loop for `debug_regexp` I wont guarantee this makes the code 100% bugfree, but at least it solves my case. 


This is what happened:
```
bounds: (0, 2542)
half: 1271
bounds: (0, 1270)
half: 635
bounds: (0, 634)
half: 317
bounds: (0, 316)
half: 158
bounds: (0, 157)
half: 78
bounds: (0, 77)
half: 38
bounds: (0, 37)
half: 18
bounds: (0, 17)
half: 8
bounds: (8, 17)
half: 12
bounds: (12, 17)
half: 14
bounds: (14, 17)
half: 15
bounds: (15, 17)
half: 16
bounds: (16, 17)
half: 16
bounds: (16, 17)
half: 16
bounds: (16, 17)
half: 16
bounds: (16, 17)
half: 16
...
```