### PR TITLE
Keep outputs with edid when loading profiles

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -242,17 +242,17 @@ class XrandrOutput(object):
             if line:
                 line = line.split(None, 1)
                 options[line[0]] = line[1] if len(line) > 1 else None
-        if "off" in options:
+
+        if options["output"] in edid_map:
+            edid = edid_map[options["output"]]
+        elif "off" in options:
             edid = None
         else:
-            if options["output"] in edid_map:
-                edid = edid_map[options["output"]]
-            else:
-                fuzzy_edid_map = [ re.sub("(card[0-9]+|-)", "", x) for x in edid_map.keys() ]
-                fuzzy_output = re.sub("(card[0-9]+|-)", "", options["output"])
-                if fuzzy_output not in fuzzy_edid_map:
-                    raise RuntimeError("Failed to find a corresponding output in config/setup for output `%s'" % options["output"])
-                edid = edid_map[list(edid_map.keys())[fuzzy_edid_map.index(fuzzy_output)]]
+            fuzzy_edid_map = [ re.sub("(card[0-9]+|-)", "", x) for x in edid_map.keys() ]
+            fuzzy_output = re.sub("(card[0-9]+|-)", "", options["output"])
+            if fuzzy_output not in fuzzy_edid_map:
+                raise RuntimeError("Failed to find a corresponding output in config/setup for output `%s'" % options["output"])
+            edid = edid_map[list(edid_map.keys())[fuzzy_edid_map.index(fuzzy_output)]]
         output = options["output"]
         del options["output"]
 
@@ -340,7 +340,7 @@ def load_profiles(profile_path):
                 buffer.append(line)
 
         for output_name in list(config.keys()):
-            if "off" in config[output_name].options:
+            if config[output_name].edid is None:
                 del config[output_name]
 
         profiles[profile] = config

--- a/autorandr.py
+++ b/autorandr.py
@@ -243,16 +243,20 @@ class XrandrOutput(object):
                 line = line.split(None, 1)
                 options[line[0]] = line[1] if len(line) > 1 else None
 
+        edid = None
+
         if options["output"] in edid_map:
             edid = edid_map[options["output"]]
-        elif "off" in options:
-            edid = None
         else:
+            # This fuzzy matching is for legacy autorandr that used sysfs output names
             fuzzy_edid_map = [ re.sub("(card[0-9]+|-)", "", x) for x in edid_map.keys() ]
             fuzzy_output = re.sub("(card[0-9]+|-)", "", options["output"])
-            if fuzzy_output not in fuzzy_edid_map:
-                raise RuntimeError("Failed to find a corresponding output in config/setup for output `%s'" % options["output"])
-            edid = edid_map[list(edid_map.keys())[fuzzy_edid_map.index(fuzzy_output)]]
+            if fuzzy_output in fuzzy_edid_map:
+                edid = edid_map[list(edid_map.keys())[fuzzy_edid_map.index(fuzzy_output)]]
+            elif "off" not in options:
+                raise RuntimeError("Failed to find an EDID for output `%s' in setup file, required as `%s' is not off in config file."
+                                   % (options["output"], options["output"])
+
         output = options["output"]
         del options["output"]
 


### PR DESCRIPTION
fixes #13

2181c8ef025f4e0997a4393832b3d686f5990d3d was only concerned with reading from `xrandr` and not from saved profiles. This commit fixes this part.