### PR TITLE
Use XDG Base Directory Specification for config files

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -67,7 +67,7 @@ Usage: autorandr [options]
  --default <profile>.
 
  Another script called "postswitch "can be placed in the directory
- ~/.autorandr as well as in any profile directories: The scripts are executed
+ ~/.config/autorandr as well as in any profile directories: The scripts are executed
  after a mode switch has taken place and can notify window managers.
 
  The following virtual configurations are available:
@@ -496,7 +496,11 @@ def main(argv):
         print(str(e))
         options = { "--help": True }
 
-    profile_path = os.path.expanduser("~/.autorandr")
+    profile_dir = os.path.expanduser("~/.autorandr")
+    if not os.path.isdir(profile_dir):
+        profile_dir = os.path.join(os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")), "autorandr")
+
+    profile_path = os.path.join(profile_dir, "profiles")
 
     try:
         profiles = load_profiles(profile_path)

--- a/bash_completion/autorandr
+++ b/bash_completion/autorandr
@@ -12,6 +12,8 @@ _autorandr ()
 	lopts="--help --change --save --load --default --force --fingerprint --config --dry-run"
 	if [ -d ~/.autorandr ]; then
 		prfls="`find ~/.autorandr/* -maxdepth 1 -type d -printf '%f\n'`"
+	if [ -d ~/.config/autorandr ]; then
+		prfls="`find ~/.config/autorandr/* -maxdepth 1 -type d -printf '%f\n'`"
 	else
 		prfls=""
 	fi


### PR DESCRIPTION
This is PR #11, rebased for the new python master branch.

> it would be really nice if autorandr would not clutter my home directory.
> 
>I suggest respecting the XDG Base Directory Specification and move the configuration to ~/.config/autorandr.
>
>This PR should not be considered complete. 
>A final implementaion should check for the $XDG_CONFIG_HOME environment variable and fallback to $HOME/.config if it's not defined.
>
>Maybe there could be also a be $AUTORANDR_CONFIG_HOME env to overwrite the default behaviour and >overwrite the config location entirely.
>
>Also a upgrade/migration from the old config location to the new one would be nice.
>
>I am not really a python guy so before doing a complete implementation I am looking forward to get some >opinions.