### PR TITLE
py3: import reduce from functools

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -34,6 +34,7 @@ import subprocess
 import sys
 from distutils.version import LooseVersion as Version
 
+from functools import reduce
 from itertools import chain
 from collections import OrderedDict
 


### PR DESCRIPTION
This works for Python 2, too (tested on 2.6 and 2.7).