### PR TITLE
The 40autorandr script needs to be executable for udev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ DEFAULT_TARGETS+=pmutils
 endif
 
 install_pmutils:
-	install -D -m 644 contrib/pm-utils/40autorandr ${DESTDIR}/etc/pm/sleep.d/40autorandr
+	install -D -m 755 contrib/pm-utils/40autorandr ${DESTDIR}/etc/pm/sleep.d/40autorandr
 
 uninstall_pmutils:
 	rm -f ${DESTDIR}/etc/pm/sleep.d/40autorandr


### PR DESCRIPTION
Otherwise it will not be executed:
```
… systemd-udevd[32358]: failed to execute '/etc/pm/sleep.d/40autorandr' '/etc/pm/sleep.d/40autorandr thaw': Permission denied
… systemd-udevd[32355]: Process '/etc/pm/sleep.d/40autorandr thaw' failed with exit code 2.
```