### PR TITLE
Add ability to remove profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Contributors to this version of autorandr are:
 * stormc
 * tachylatus
 * andersonjacob
+* Simon Wydooghe
 
 ## How to use
 

--- a/autorandr.py
+++ b/autorandr.py
@@ -40,6 +40,10 @@ from distutils.version import LooseVersion as Version
 from functools import reduce
 from itertools import chain
 
+try:
+    input = raw_input
+except NameError:
+    pass
 
 virtual_profiles = [
     # (name, description, callback)
@@ -807,7 +811,7 @@ def main(argv):
             profile_dirlist.remove("config")
             profile_dirlist.remove("setup")
             if profile_dirlist:
-                print("Profile folder '%s' contains the following:\n---\n%s\n---" % (options["--remove"], "\n".join(profile_dirlist)))
+                print("Profile folder '%s' contains the following additional files:\n---\n%s\n---" % (options["--remove"], "\n".join(profile_dirlist)))
                 response = input("Do you really want to remove profile '%s'? If so, type 'yes': " % options["--remove"]).strip()
                 if response != "yes":
                     remove = False

--- a/autorandr.py
+++ b/autorandr.py
@@ -801,11 +801,23 @@ def main(argv):
         if options["--remove"] not in profiles.keys():
             raise AutorandrException("Cannot remove profile '%s':\nThis profile does not exist." % options["--remove"])
         try:
+            remove = True
             profile_folder = os.path.join(profile_path, options["--remove"])
-            shutil.rmtree(profile_folder)
+            profile_dirlist = os.listdir(profile_folder)
+            profile_dirlist.remove("config")
+            profile_dirlist.remove("setup")
+            if profile_dirlist:
+                print("Profile folder '%s' contains the following:\n---\n%s\n---" % (options["--remove"], "\n".join(profile_dirlist)))
+                response = input("Do you really want to remove profile '%s'? If so, type 'yes': " % options["--remove"]).strip()
+                if response != "yes":
+                    remove = False
+            if remove is True:
+                shutil.rmtree(profile_folder)
+                print("Removed profile '%s'" % options["--remove"])
+            else:
+                print("Profile '%s' was not removed" % options["--remove"])
         except Exception as e:
             raise AutorandrException("Failed to remove profile '%s'" % (options["--remove"],), e)
-        print("Removed profile '%s'" % options["--remove"])
         sys.exit(0)
 
     if "-h" in options or "--help" in options:

--- a/autorandr.py
+++ b/autorandr.py
@@ -33,6 +33,7 @@ import posix
 import re
 import subprocess
 import sys
+import shutil
 
 from collections import OrderedDict
 from distutils.version import LooseVersion as Version
@@ -53,6 +54,7 @@ Usage: autorandr [options]
 -h, --help              get this small help
 -c, --change            reload current setup
 -s, --save <profile>    save your current setup to profile <profile>
+-r, --remove <profile>  remove profile <profile>
 -l, --load <profile>    load profile <profile>
 -d, --default <profile> make profile <profile> the default profile
 --skip-options <option> comma separated list of xrandr arguments (e.g. "gamma")
@@ -731,7 +733,7 @@ def exec_scripts(profile_path, script_name, meta_information=None):
 
 def main(argv):
     try:
-       options = dict(getopt.getopt(argv[1:], "s:l:d:cfh", [ "dry-run", "change", "default=", "save=", "load=", "force", "fingerprint", "config", "debug", "skip-options=", "help" ])[0])
+        options = dict(getopt.getopt(argv[1:], "s:r:l:d:cfh", [ "dry-run", "change", "default=", "save=", "remove=", "load=", "force", "fingerprint", "config", "debug", "skip-options=", "help" ])[0])
     except getopt.GetoptError as e:
         print("Failed to parse options: {0}.\n"
               "Use --help to get usage information.".format(str(e)),
@@ -789,6 +791,21 @@ def main(argv):
         except Exception as e:
             raise AutorandrException("Failed to save current configuration as profile '%s'" % (options["--save"],), e)
         print("Saved current configuration as profile '%s'" % options["--save"])
+        sys.exit(0)
+
+    if "-r" in options:
+        options["--remove"] = options["-r"]
+    if "--remove" in options:
+        if options["--remove"] in ( x[0] for x in virtual_profiles ):
+            raise AutorandrException("Cannot remove profile '%s':\nThis configuration name is a reserved virtual configuration." % options["--remove"])
+        if options["--remove"] not in profiles.keys():
+            raise AutorandrException("Cannot remove profile '%s':\nThis profile does not exist." % options["--remove"])
+        try:
+            profile_folder = os.path.join(profile_path, options["--remove"])
+            shutil.rmtree(profile_folder)
+        except Exception as e:
+            raise AutorandrException("Failed to remove profile '%s'" % (options["--remove"],), e)
+        print("Removed profile '%s'" % options["--remove"])
         sys.exit(0)
 
     if "-h" in options or "--help" in options:

--- a/contrib/bash_completion/autorandr
+++ b/contrib/bash_completion/autorandr
@@ -8,8 +8,8 @@ _autorandr ()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-	opts="-h -c -s -l -d"
-	lopts="--help --change --save --load --default --force --fingerprint --config --dry-run"
+	opts="-h -c -s -r -l -d"
+	lopts="--help --change --save --remove --load --default --force --fingerprint --config --dry-run"
 	if [ -d ~/.autorandr ]; then
 		prfls="`find ~/.autorandr/* -maxdepth 1 -type d -printf '%f\n'`"
 	elif [ -d ~/.config/autorandr ]; then
@@ -35,7 +35,7 @@ _autorandr ()
 		esac
 
 	case "${prev}" in
-		-l|--load|-d|--default)
+		-r|--remove|-l|--load|-d|--default)
 			COMPREPLY=( $( compgen -W "${prfls}" -- $cur ) )
 			return 0
 			;;


### PR DESCRIPTION
This commit adds profile removal ability.
You can use '-r' or '--remove'.

Following checks are done:
* not a virtual profile
* profile can be found in profiles.keys()
* in case of files other than setup and config being present in the
profile folder, user confirmation is necessary to delete the
profile in question

Also added the remove option to the bash completion (untested though,
using zsh and quite unfamiliar with it).

I'm far from a good programmer. Please check if I missed something, but I think i covered the bases.