### PR TITLE
Allow 40autorandr to handle any order fields from loginctl

### DIFF
--- a/contrib/pm-utils/40autorandr
+++ b/contrib/pm-utils/40autorandr
@@ -18,20 +18,28 @@ find_user() {
 		# by SO user intelfx
 		user="$(
 		loginctl list-sessions --no-legend | while read id uid user seat; do
-			 loginctl show-session -p Display -p Active "$id" | while IFS='=' read property value; do
-				case "$property" in
-					Active)
-						if [ "$value" != "yes" ]; then
-							continue
-						fi
-						;;
-					Display)
-						if [ -n "$value" -a "$value" = "$D" ]; then
-							echo $user
-						fi
-						;;
-				esac
-			done
+			session=$(loginctl show-session -p Display -p Active "$id")
+			first=$(echo $session | cut -d" " -f1)
+			second=$(echo $session | cut -d" " -f2)
+
+			if [ -n $(echo "$first" | grep "Display") ]; then
+				display=$first
+				active=$second
+			else
+				display=$second
+				active=$first
+			fi
+
+			active_value=$(echo "$active" | cut -d"=" -f2)
+			display_value=$(echo "$display" | cut -d"=" -f2)
+
+			if [ "$active_value" != "yes" ]; then
+				continue
+			fi
+
+			if [ -n $display_value -a "$display_value" = "$D" ]; then
+				echo $user
+			fi
 		done
 		)"
 		if [ -n "$user" ]; then


### PR DESCRIPTION
This could be done a great deal more cleanly using bash regex matching;
however, as is stated elsewhere, the script will not always be executed
with bash.

There may be some merit to causing the script to always be executed with
bash (`#! /bin/bash` or even `#! /usr/bin/env bash`), but I'll admit I
don't know how widely installed bash is. I've certainly never found a
modern Linux install without bash, but my experience isn't the widest.

Fixes #52 