### PR TITLE
Autostart config added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DESTDIR=/
 PREFIX=/usr/
 
-.PHONY: all install uninstall autorandr bash_completion pmutils systemd udev
+.PHONY: all install uninstall autorandr bash_completion autostart_config pmutils systemd udev
 
 all:
 	@echo "Call \"make install\" to install this program."
@@ -36,6 +36,15 @@ install_bash_completion:
 
 uninstall_bash_completion:
 	rm -f ${DESTDIR}/${BASH_COMPLETION_DIR}/autorandr
+
+# Rules for autostart config
+XDG_AUTOSTART_DIR=/etc/xdg/autostart
+
+install_autostart_config:
+	install -D -m 644 contrib/etc/xdg/autostart/autorandr.desktop ${DESTDIR}/${XDG_AUTOSTART_DIR}/autorandr.desktop
+
+uninstall_autostart_config:
+	rm -f ${DESTDIR}/${XDG_AUTOSTART_DIR}/autorandr.desktop
 
 # Rules for pmutils
 PM_UTILS_DIR=/etc/pm/sleep.d

--- a/contrib/etc/xdg/autostart/autorandr.desktop
+++ b/contrib/etc/xdg/autostart/autorandr.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Autorandr
+Comment=Automatically select a display configuration based on connected devices
+Type=Application
+Exec=/usr/bin/autorandr -c --default default
+X-GNOME-Autostart-Phase=Initialization

--- a/contrib/packaging/debian/make_deb.sh
+++ b/contrib/packaging/debian/make_deb.sh
@@ -34,7 +34,7 @@ mkdir $D
 # Debian(ish) specific part
 make -C "$P/../../../" \
 	DESTDIR="$D" \
-	TARGETS="autorandr bash_completion pmutils systemd udev" \
+	TARGETS="autorandr bash_completion autostart_config pmutils systemd udev" \
 	BASH_COMPLETION_DIR=/usr/share/bash-completion/completions \
 	SYSTEMD_UNIT_DIR=/lib/systemd/system \
 	PM_UTILS_DIR=/usr/lib/pm-utils/sleep.d \
@@ -44,7 +44,7 @@ make -C "$P/../../../" \
 SIZE=$(du -s $D | awk '{print $1}')
 
 cp -r "$P/debian" "$D/DEBIAN"
-[ -d "$D/etc" ] && (cd $D; find etc) > "$D/DEBIAN/conffiles"
+[ -d "$D/etc" ] && (cd $D; find etc -type f) > "$D/DEBIAN/conffiles"
 sed -i -re "s#Version:.+#Version: $V#" "$D/DEBIAN/control"
 echo "Installed-Size: $SIZE" >> "$D/DEBIAN/control"
 fakeroot dpkg-deb -b "$D" "$O"


### PR DESCRIPTION
Without this configuration is not applied until plug/unplug external monitor.
This way it applies configuration on login.

Checked on Ubuntu 16.10 x64, works fine.