### PR TITLE
Makefile: fix install path for udev rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ uninstall_systemd:
 	rm -f ${DESTDIR}/${SYSTEMD_UNIT_DIR}/autorandr-resume.service
 
 # Rules for udev
-UDEV_RULES_DIR:=$(shell pkg-config --variable=udevdir udev 2>/dev/null)
+UDEV_RULES_DIR:=$(shell pkg-config --variable=udevdir udev 2>/dev/null)/rules.d
 ifneq (,$(UDEV_RULES_DIR),y)
 DEFAULT_TARGETS+=udev
 endif


### PR DESCRIPTION
`pkg-config --variable=udevdir udev` returns the root folder for udev. (for my Ubuntu `/lib/udev`). Rules should be put under `<root-folder>/rules.d/`

This has been reported as a bug on the Arch package as well https://aur.archlinux.org/packages/autorandr-git/