### PR TITLE
Fix systemd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,12 +77,19 @@ ifneq (,$(SYSTEMD_UNIT_DIR))
 DEFAULT_TARGETS+=systemd
 endif
 
+# `systemctl preset` will enable the service is that is the default on the
+# installed system, and otherwise will try to disable the service, which won't
+# do anything
 install_systemd:
 	$(if $(SYSTEMD_UNIT_DIR),,$(error SYSTEMD_UNIT_DIR is not defined))
 	install -D -m 644 contrib/systemd/autorandr-resume.service ${DESTDIR}/${SYSTEMD_UNIT_DIR}/autorandr-resume.service
+	systemctl preset autorandr-resume.service
 
+# `systemctl disable` will clean up if the service was enabled, and otherwise do
+# nothing
 uninstall_systemd:
 	$(if $(SYSTEMD_UNIT_DIR),,$(error SYSTEMD_UNIT_DIR is not defined))
+	systemctl disable autorandr-resume.service
 	rm -f ${DESTDIR}/${SYSTEMD_UNIT_DIR}/autorandr-resume.service
 
 # Rules for udev

--- a/contrib/systemd/autorandr-resume.service
+++ b/contrib/systemd/autorandr-resume.service
@@ -1,9 +1,12 @@
 [Unit]
 Description=autorandr resume hook
 After=sleep.target
+StopWhenUnneeded=yes
 
 [Service]
-ExecStart=/usr/bin/autorandr --batch -c --default default
+Type=oneshot
+RemainAfterExit=yes
+ExecStop=/usr/bin/autorandr --batch --change --default default
 
 [Install]
 WantedBy=sleep.target


### PR DESCRIPTION
I ran into two problems that I fixed in this PR.

1. The systemd service was not enabled, because `systemctl enable autorandr-resume.service` wasn't run. (I've added this to the Makefile)
2. Even though the old script has `After=sleep.target`, autorandr was run at the moment I suspended/hibernated, and not when I resumed.

This patch works on my Ubuntu 16.04, but if you are running systemd locally, you might want to verify it as well.