### PR TITLE
Use systemd from udev and instead of pmutils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,26 @@ install_autostart_config:
 uninstall_autostart_config:
 	rm -f ${DESTDIR}/${XDG_AUTOSTART_DIR}/autorandr.desktop
 
+# Rules for systemd
+SYSTEMD_UNIT_DIR:=$(shell pkg-config --variable=systemdsystemunitdir systemd 2>/dev/null)
+ifneq (,$(SYSTEMD_UNIT_DIR))
+DEFAULT_TARGETS+=systemd
+endif
+
+install_systemd:
+	$(if $(SYSTEMD_UNIT_DIR),,$(error SYSTEMD_UNIT_DIR is not defined))
+	install -D -m 644 contrib/systemd/autorandr.service ${DESTDIR}/${SYSTEMD_UNIT_DIR}/autorandr.service
+
+uninstall_systemd:
+	$(if $(SYSTEMD_UNIT_DIR),,$(error SYSTEMD_UNIT_DIR is not defined))
+	rm -f ${DESTDIR}/${SYSTEMD_UNIT_DIR}/autorandr.service
+
 # Rules for pmutils
 PM_SLEEPHOOKS_DIR:=$(shell pkg-config --variable=pm_sleephooks pm-utils 2>/dev/null)
 ifneq (,$(PM_SLEEPHOOKS_DIR))
+ifeq (,$(SYSTEMD_UNIT_DIR))
 DEFAULT_TARGETS+=pmutils
+endif
 endif
 
 install_pmutils:
@@ -71,19 +87,6 @@ uninstall_pmutils:
 	$(if $(PM_SLEEPHOOKS_DIR),,$(error PM_SLEEPHOOKS_DIR is not defined))
 	rm -f ${DESTDIR}/${PM_SLEEPHOOKS_DIR}/40autorandr
 
-# Rules for systemd
-SYSTEMD_UNIT_DIR:=$(shell pkg-config --variable=systemdsystemunitdir systemd 2>/dev/null)
-ifneq (,$(SYSTEMD_UNIT_DIR))
-DEFAULT_TARGETS+=systemd
-endif
-
-install_systemd:
-	$(if $(SYSTEMD_UNIT_DIR),,$(error SYSTEMD_UNIT_DIR is not defined))
-	install -D -m 644 contrib/systemd/autorandr-resume.service ${DESTDIR}/${SYSTEMD_UNIT_DIR}/autorandr-resume.service
-
-uninstall_systemd:
-	$(if $(SYSTEMD_UNIT_DIR),,$(error SYSTEMD_UNIT_DIR is not defined))
-	rm -f ${DESTDIR}/${SYSTEMD_UNIT_DIR}/autorandr-resume.service
 
 # Rules for udev
 UDEV_RULES_DIR:=$(shell pkg-config --variable=udevdir udev 2>/dev/null)/rules.d

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ DEFAULT_TARGETS+=autostart_config
 
 install_autostart_config:
 	install -D -m 644 contrib/etc/xdg/autostart/autorandr.desktop ${DESTDIR}/${XDG_AUTOSTART_DIR}/autorandr.desktop
+ifneq ($(PREFIX),/usr/)
+	sed -i -re 's#/usr/bin/autorandr#$(subst #,\#,${PREFIX})/bin/autorandr#g' ${DESTDIR}/${XDG_AUTOSTART_DIR}/autorandr.desktop
+endif
 
 uninstall_autostart_config:
 	rm -f ${DESTDIR}/${XDG_AUTOSTART_DIR}/autorandr.desktop
@@ -66,6 +69,9 @@ endif
 install_systemd:
 	$(if $(SYSTEMD_UNIT_DIR),,$(error SYSTEMD_UNIT_DIR is not defined))
 	install -D -m 644 contrib/systemd/autorandr.service ${DESTDIR}/${SYSTEMD_UNIT_DIR}/autorandr.service
+ifneq ($(PREFIX),/usr/)
+	sed -i -re 's#/usr/bin/autorandr#$(subst #,\#,${PREFIX})/bin/autorandr#g' ${DESTDIR}/${SYSTEMD_UNIT_DIR}/autorandr.service
+endif
 
 uninstall_systemd:
 	$(if $(SYSTEMD_UNIT_DIR),,$(error SYSTEMD_UNIT_DIR is not defined))
@@ -82,6 +88,9 @@ endif
 install_pmutils:
 	$(if $(PM_SLEEPHOOKS_DIR),,$(error PM_SLEEPHOOKS_DIR is not defined))
 	install -D -m 755 contrib/pm-utils/40autorandr ${DESTDIR}/${PM_SLEEPHOOKS_DIR}/40autorandr
+ifneq ($(PREFIX),/usr/)
+	sed -i -re 's#/usr/bin/autorandr#$(subst #,\#,${PREFIX})/bin/autorandr#g' ${DESTDIR}/${PM_SLEEPHOOKS_DIR}/40autorandr
+endif
 
 uninstall_pmutils:
 	$(if $(PM_SLEEPHOOKS_DIR),,$(error PM_SLEEPHOOKS_DIR is not defined))

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,11 @@ install_systemd:
 ifneq ($(PREFIX),/usr/)
 	sed -i -re 's#/usr/bin/autorandr#$(subst #,\#,${PREFIX})/bin/autorandr#g' ${DESTDIR}/${SYSTEMD_UNIT_DIR}/autorandr.service
 endif
+	@echo
+	@echo "To activate the systemd unit, run this command as root:"
+	@echo "    systemctl daemon-reload"
+	@echo "    systemctl enable autorandr.service"
+	@echo
 
 uninstall_systemd:
 	$(if $(SYSTEMD_UNIT_DIR),,$(error SYSTEMD_UNIT_DIR is not defined))
@@ -107,12 +112,10 @@ install_udev:
 	$(if $(UDEV_RULES_DIR),,$(error UDEV_RULES_DIR is not defined))
 	mkdir -p ${DESTDIR}/${UDEV_RULES_DIR}/
 	echo 'ACTION=="change", SUBSYSTEM=="drm", RUN+="$(if $(findstring systemd, $(TARGETS)),/bin/systemctl start autorandr.service,${PREFIX}/bin/autorandr --batch --change --default default)"' > ${DESTDIR}/${UDEV_RULES_DIR}/40-monitor-hotplug.rules
-ifeq (${USER},root)
-	udevadm control --reload-rules
-else
-	@echo "Please run this command as root:"
+	@echo
+	@echo "To activate the udev rules, run this command as root:"
 	@echo "    udevadm control --reload-rules"
-endif
+	@echo
 
 uninstall_udev:
 	$(if $(UDEV_RULES_DIR),,$(error UDEV_RULES_DIR is not defined))

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,8 @@ endif
 
 install_udev:
 	$(if $(UDEV_RULES_DIR),,$(error UDEV_RULES_DIR is not defined))
-	install -D -m 644 contrib/udev/40-monitor-hotplug.rules ${DESTDIR}/${UDEV_RULES_DIR}/40-monitor-hotplug.rules
+	mkdir -p ${DESTDIR}/${UDEV_RULES_DIR}/
+	echo 'ACTION=="change", SUBSYSTEM=="drm", RUN+="$(if $(findstring systemd, $(TARGETS)),/bin/systemctl start autorandr.service,${PREFIX}/bin/autorandr --batch --change --default default)"' > ${DESTDIR}/${UDEV_RULES_DIR}/40-monitor-hotplug.rules
 ifeq (${USER},root)
 	udevadm control --reload-rules
 else

--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ about it. The same holds for `preswitch`, which is executed before the switch
 takes place, and `postsave`, which is executed after a profile was
 stored/altered.
 
+If you experience issues with xrandr being executed too early after connecting
+a new monitor, then you can create a script `predetect`, which will be executed
+before autorandr attempts to run xrandr. Place e.g. `sleep 1` into that file
+to make autorandr wait a second before running xrandr.
+
 All scripts can also be placed in any of the `$XDG_CONFIG_DIRS`. In addition to
 the script names themselves, any executables in subdirectories named
 `script_name.d` (e.g. `postswitch.d`) are executed as well. In scripts, some of
@@ -131,6 +136,7 @@ The most useful one is `$AUTORANDR_CURRENT_PROFILE`.
 ## Changelog
 
 * *2017-01-18* Accept comments (lines starting with `#`) in config/setup files
+* *2017-01-20* New script hook, `predetect`
 
 **autorandr 1.0**
 

--- a/autorandr.py
+++ b/autorandr.py
@@ -843,6 +843,9 @@ def dispatch_call_to_sessions(argv):
                 process_environ[name] = value
         display = process_environ["DISPLAY"] if "DISPLAY" in process_environ else None
 
+        # To allow scripts to detect batch invocation (especially useful for predetect)
+        process_environ["AUTORANDR_BATCH_PID"] = os.getpid()
+
         if display and display not in X11_displays_done:
             try:
                 pwent = pwd.getpwuid(uid)

--- a/autorandr.py
+++ b/autorandr.py
@@ -881,6 +881,9 @@ def main(argv):
               file=sys.stderr)
         sys.exit(posix.EX_USAGE)
 
+    if "-h" in options or "--help" in options:
+        exit_help()
+
     # Batch mode
     if "--batch" in options:
         if ("DISPLAY" not in os.environ or not os.environ["DISPLAY"]) and os.getuid() == 0:
@@ -974,9 +977,6 @@ def main(argv):
         except Exception as e:
             raise AutorandrException("Failed to remove profile '%s'" % (options["--remove"],), e)
         sys.exit(0)
-
-    if "-h" in options or "--help" in options:
-        exit_help()
 
     detected_profiles = find_profiles(config, profiles)
     load_profile = False

--- a/contrib/packaging/debian/make_deb.sh
+++ b/contrib/packaging/debian/make_deb.sh
@@ -34,7 +34,7 @@ mkdir $D
 # Debian(ish) specific part
 make -C "$P/../../../" \
 	DESTDIR="$D" \
-	TARGETS="autorandr bash_completion autostart_config pmutils systemd udev" \
+	TARGETS="autorandr bash_completion autostart_config systemd udev" \
 	BASH_COMPLETION_DIR=/usr/share/bash-completion/completions \
 	SYSTEMD_UNIT_DIR=/lib/systemd/system \
 	PM_UTILS_DIR=/usr/lib/pm-utils/sleep.d \

--- a/contrib/pm-utils/40autorandr
+++ b/contrib/pm-utils/40autorandr
@@ -5,6 +5,6 @@ exec > /var/log/autorandr.log 2>&1
 
 case "$1" in
 	thaw|resume)
-		autorandr --batch -c --default default
+		/usr/bin/autorandr --batch --change --default default
 		;;
 esac

--- a/contrib/systemd/autorandr-resume.service
+++ b/contrib/systemd/autorandr-resume.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=autorandr resume hook
-After=sleep.target
-
-[Service]
-ExecStart=/usr/bin/autorandr --batch -c --default default
-
-[Install]
-WantedBy=sleep.target

--- a/contrib/systemd/autorandr.service
+++ b/contrib/systemd/autorandr.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=autorandr execution hook
+After=sleep.target
+
+[Service]
+ExecStart=/usr/local/bin/autorandr --batch --change --default default
+Type=oneshot
+RemainAfterExit=false
+
+[Install]
+WantedBy=sleep.target

--- a/contrib/systemd/autorandr.service
+++ b/contrib/systemd/autorandr.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=autorandr execution hook
 After=sleep.target
+StartLimitInterval=5
+StartLimitBurst=1
 
 [Service]
 ExecStart=/usr/bin/autorandr --batch --change --default default

--- a/contrib/systemd/autorandr.service
+++ b/contrib/systemd/autorandr.service
@@ -3,7 +3,7 @@ Description=autorandr execution hook
 After=sleep.target
 
 [Service]
-ExecStart=/usr/local/bin/autorandr --batch --change --default default
+ExecStart=/usr/bin/autorandr --batch --change --default default
 Type=oneshot
 RemainAfterExit=false
 

--- a/contrib/udev/40-monitor-hotplug.rules
+++ b/contrib/udev/40-monitor-hotplug.rules
@@ -1,1 +1,1 @@
-ACTION=="change", SUBSYSTEM=="drm", RUN+="/usr/bin/autorandr --batch -c --default default"
+ACTION=="change", SUBSYSTEM=="drm", RUN+="/bin/systemctl start autorandr.service"

--- a/contrib/udev/40-monitor-hotplug.rules
+++ b/contrib/udev/40-monitor-hotplug.rules
@@ -1,1 +1,0 @@
-ACTION=="change", SUBSYSTEM=="drm", RUN+="/bin/systemctl start autorandr.service"


### PR DESCRIPTION
This is an idea for how we could resolve #61 and get rid of the pmutils scripts on Debian.

What would change by this PR:

* pmutils script does no longer get installed by default if systemd is in use; the systemd unit already executes autorandr upon waking from sleep
* the udev rule now uses systemd to start autorandr, allowing for longer runtimes without triggering any kill timeouts (udev kills long running processes)

Auxiliary changes:

* the Makefile now adjusts paths in the scripts/config files depending on the `$PREFIX`
* the udev rule is now dynamically created, calling either systemd or autorandr directly if systemd is unavailable

This affects #60 as well.