### PR TITLE
pip installable!

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ list of what exactly will be installed.
 We appreciate packaging scripts for other distributions, please file a pull
 request if you write one.
 
-On any distribution with `pip` installed you can install it with:
-```
-sudo pip install -e git+http://github.com/phillipberndt/autorandr#egg=autorandr
-```
+If you prefer `pip` over your package manager, you can install autorandr with:
+
+    sudo pip install "git+http://github.com/phillipberndt/autorandr#egg=autorandr"
+
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ list of what exactly will be installed.
 We appreciate packaging scripts for other distributions, please file a pull
 request if you write one.
 
+On any distribution with `pip` installed you can install it with:
+```
+sudo pip install -e git+http://github.com/phillipberndt/autorandr#egg=autorandr
+```
+
 ## How to use
 
 Save your current display configuration and setup with:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,45 @@
+from setuptools import setup
+
+
+long_description = open('README.md').read()
+
+setup(
+    name='autorandr',
+
+    #version='', # FIXME
+
+    description='Automatically select a display configuration based on connected devices',
+    long_description=long_description,
+
+    url='https://github.com/phillipberndt/autorandr',
+
+    author='Phillip Berndt',
+
+    license='GPLv3',
+
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        'Environment :: Console',
+
+        'Intended Audience :: End Users/Desktop',
+
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+    ],
+
+    keywords='xrandr',
+
+    py_modules=['autorandr'],
+
+    entry_points={
+        'console_scripts': [
+            'autorandr = autorandr:exception_handled_main',
+        ],
+    },
+)


### PR DESCRIPTION
I'd love the simplicity of `sudo pip install autorandr` so I made a `setup.py` file for it :smiley: 

It kinda addresses #54, but via PyPi & `pip` rather than a Debian package. A `.deb` would definitely still be great because it can more easily/correctly install systemd & udev rules. Similarly to packaging for Debian, it'd be best if autorandr was versioned. I also don't mind semver, but agree it's probably overkill for such a tool(semver is best suited for versioning libraries, imo).

I also made `sys.arv` the default value for the arg to `main()` so that the `setuptools`'s `entry_points` feature will work.

I agree with the singlefile simplicity as discussed in #12 and just want to offer `pip` as an _option_.