### PR TITLE
Bug fix: ensure that the Debian control directory has permissions 0755.

### DIFF
--- a/contrib/packaging/debian/make_deb.sh
+++ b/contrib/packaging/debian/make_deb.sh
@@ -44,6 +44,7 @@ make -C "$P/../../../" \
 SIZE=$(du -s $D | awk '{print $1}')
 
 cp -r "$P/debian" "$D/DEBIAN"
+chmod 0755 "$D/DEBIAN"
 [ -d "$D/etc" ] && (cd $D; find etc -type f) > "$D/DEBIAN/conffiles"
 sed -i -re "s#Version:.+#Version: $V#" "$D/DEBIAN/control"
 echo "Installed-Size: $SIZE" >> "$D/DEBIAN/control"


### PR DESCRIPTION
Hi,
In a environment with a restrictive umask (s.g., umask 077), building Debian packages fails as the Debian control directory has to restrictive permissions (and not the required 0755). Adding an explicit chmod call ensures the right permission (alternatively, setting the umask in make_deb_sh to a more relaxed setting, e.g., 022, might work as well). 

Best,
Achim  