### PR TITLE
Removed pm-utils on fedora22+ from requisites

### DIFF
--- a/contrib/packaging/autorandr.spec
+++ b/contrib/packaging/autorandr.spec
@@ -1,6 +1,14 @@
+%define use_pm_utils 1
+%if 0%{?fedora} > 22
+%define use_pm_utils 0
+%endif
+%if 0%{?rhel} > 7
+%define use_pm_utils 0
+%endif
+
 Name:           autorandr
 Version:        1.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Automatically select a display configuration based on connected devices
 
 License:        GPL
@@ -8,7 +16,10 @@ URL:            https://github.com/phillipberndt/autorandr
 Source0:        https://github.com/phillipberndt/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
 
 BuildArch:	noarch
-Requires:       systemd udev bash-completion pm-utils
+Requires:       systemd
+%if 0%{?use_pm_utils}
+Requires:	pm-utils
+%endif
 
 %description
 
@@ -21,7 +32,9 @@ Requires:       systemd udev bash-completion pm-utils
 %install
 
 install -D -m 755 autorandr.py %{buildroot}%{_bindir}/autorandr
-install -D -m 644 contrib/bash_completion/autorandr %{buildroot}%{_sysconfdir}/bash_completion.d/autorandr
+install -D -m 644 contrib/bash_completion/autorandr %{buildroot}%{_datarootdir}/autorandr/completions/autorandr
+install -d -m 755 %{buildroot}%{_datarootdir}/bash-completion/completions
+ln -s ../../autorandr/completions/autorandr %{buildroot}%{_datarootdir}/bash-completion/completions/autorandr
 install -D -m 755 contrib/pm-utils/40autorandr %{buildroot}%{_sysconfdir}/pm/sleep.d/40autorandr
 install -D -m 644 contrib/systemd/autorandr.service %{buildroot}%{_sysconfdir}/systemd/system/autorandr.service
 #install -D -m 644 contrib/udev/40-monitor-hotplug.rules %{buildroot}%{_sysconfdir}/udev/rules.d/40-monitor-hotplug.rules
@@ -34,12 +47,18 @@ install -D -m 644 contrib/etc/xdg/autostart/autorandr.desktop %{buildroot}%{_sys
 %doc README.md
 %{_bindir}/*
 %config(noreplace) %{_sysconfdir}/*
+%{_datarootdir}/autorandr/*
+%{_datarootdir}/bash-completion/completions/autorandr
 
 #%post
 #udevadm control --reload-rules
 
 
 %changelog
+* Sun Oct 01 2017 Jerzy Drozdz <rpmbuilder@jdsieci.pl> - 1.1-2
+- Added conditionals for pm-utils, compability with Fedora26+
+- Removed bash-completion from requisites
+- Removed udev from requisites
 * Sun Sep 03 2017 Jerzy Drozdz <rpmbuilder@jdsieci.pl> - 1.1-1
 - Update to stable 1.1
 * Fri Feb 17 2017 Jerzy Drozdz <rpmbuilder@jdsieci.pl> - 20170217git-1


### PR DESCRIPTION
Compability changes and dependency cleanups.