### PR TITLE
systemd: Rename StartLimitInterval to StartLimitIntervalSec

### DIFF
--- a/contrib/systemd/autorandr.service
+++ b/contrib/systemd/autorandr.service
@@ -4,7 +4,7 @@ After=sleep.target
 # Note: StartLimitInterval was renamed to StartLimitIntervalSec in systemd-230.
 # See autorandr bug #69. Do not rename for now, as the old name is kept for
 # compatibility.
-StartLimitInterval=5
+StartLimitIntervalSec=5
 StartLimitBurst=1
 
 [Service]


### PR DESCRIPTION
Fixes #69.