### PR TITLE
add monitor list to hooks by environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Contributors to this version of autorandr are:
 * Adrián López
 * andersonjacob
 * Alexander Wirt
+* Brice Waegeneire
 * Chris Dunder
 * Christoph Gysin
 * Daniel Hahler
@@ -189,7 +190,11 @@ If you switch back from `docked` to `mobile`, `~/.config/autorandr/postswitch`
 is executed instead of the `mobile` specific `postswitch`.
 
 In these scripts, some of autorandr's state is exposed as environment variables
-prefixed with `AUTORANDR_`. The most useful one is `$AUTORANDR_CURRENT_PROFILE`.
+prefixed with `AUTORANDR_`, such as:
+- `AUTORANDR_CURRENT_PROFILE`
+- `AUTORANDR_CURRENT_PROFILES`
+- `AUTORANDR_PROFILE_FOLDER`
+- `AUTORANDR_MONITORS`
 
 If you experience issues with xrandr being executed too early after connecting
 a new monitor, then you can use a `predetect` script to delay the execution.

--- a/autorandr.py
+++ b/autorandr.py
@@ -1161,7 +1161,11 @@ def main(argv):
         try:
             profile_folder = os.path.join(profile_path, options["--save"])
             save_configuration(profile_folder, config)
-            exec_scripts(profile_folder, "postsave", {"CURRENT_PROFILE": options["--save"], "PROFILE_FOLDER": profile_folder})
+            exec_scripts(profile_folder, "postsave", {
+                "CURRENT_PROFILE": options["--save"],
+                "PROFILE_FOLDER": profile_folder,
+                "MONITORS": ":".join(load_config.keys()),
+            })
         except Exception as e:
             raise AutorandrException("Failed to save current configuration as profile '%s'" % (options["--save"],), e)
         print("Saved current configuration as profile '%s'" % options["--save"])
@@ -1281,6 +1285,7 @@ def main(argv):
                 script_metadata = {
                     "CURRENT_PROFILE": load_profile,
                     "PROFILE_FOLDER": scripts_path,
+                    "MONITORS": ":".join(load_config.keys()),
                 }
                 exec_scripts(scripts_path, "preswitch", script_metadata)
                 if "--debug" in options:


### PR DESCRIPTION
It's useful to have have access, in the hooks, to the new monitor list. For example to launch a status bar per monitor.

I don't know if it's the correct way to do this.