### PR TITLE
Use process kill mode in systemd service

### DIFF
--- a/contrib/systemd/autorandr.service
+++ b/contrib/systemd/autorandr.service
@@ -11,6 +11,7 @@ StartLimitBurst=1
 ExecStart=/usr/bin/autorandr --batch --change --default default
 Type=oneshot
 RemainAfterExit=false
+KillMode=process
 
 [Install]
 WantedBy=sleep.target


### PR DESCRIPTION
This allows starting background processes in postswitch scripts without having to deal with cgroups. Will resolve #111.

Can this be ported back to 3.1.0 as well?