### PR TITLE
Fix AttributeError exception in is_equal_configuration

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -768,7 +768,7 @@ def is_equal_configuration(source_configuration, target_configuration):
                 return False
     for output in source_configuration.keys():
         if "off" in source_configuration[output].options:
-            if output in target_configuration and "off" not in target_configuration.options:
+            if output in target_configuration and "off" not in target_configuration[output].options:
                 return False
         else:
             if output not in target_configuration:


### PR DESCRIPTION
```
Unhandled exception ('dict' object has no attribute 'options'). Please report this as a bug at https://github.com/phillipberndt/autorandr/issues.
Traceback (most recent call last):
  File "/usr/bin/autorandr", line 1351, in <module>
    exception_handled_main()
  File "/usr/bin/autorandr", line 1335, in exception_handled_main
    main(sys.argv)
  File "/usr/bin/autorandr", line 1240, in main
    configs_are_equal = is_equal_configuration(config, profiles[profile_name]["config"])
  File "/usr/bin/autorandr", line 771, in is_equal_configuration
    if output in target_configuration and "off" not in target_configuration.options:
AttributeError: 'dict' object has no attribute 'options'
```

Happened to me on latest master when running `autorandr` with no argument.