### PR TITLE
Consider screen rotation in `get_fb_dimensions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Contributors to this version of autorandr are:
 * Timo Kaufmann
 * Tomasz Bogdal
 * Victor Häggqvist
+* Jan-Oliver Kaiser
 
 ## Installation/removal
 

--- a/autorandr.py
+++ b/autorandr.py
@@ -645,6 +645,9 @@ def get_fb_dimensions(configuration):
             x = (a * o_width + b * o_height + c) / w
             y = (d * o_width + e * o_height + f) / w
             o_width, o_height = x, y
+        if "rotate" in output.options:
+            if output.options["rotate"] in ("left", "right"):
+                o_width, o_height = o_height, o_width
         if "pos" in output.options:
             o_left, o_top = map(int, output.options["pos"].split("x"))
             o_width += o_left


### PR DESCRIPTION
This should fix phillipberndt/autorandr#116.

I have tested it locally with a set of 3 screens (vertical-horizontal-vertical) which previously were cut off wrongly at the bottom.