### PR TITLE
Fix check for disconnected monitors (fixes #128)

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -317,7 +317,7 @@ class XrandrOutput(object):
         else:
             edid = "%s-%s" % (XrandrOutput.EDID_UNAVAILABLE, match["output"])
 
-        if not match["width"]:
+        if not match["connected"]:
             options["off"] = None
         else:
             if match["mode_name"]:


### PR DESCRIPTION
I'm not sure why the check was for width.if there's a valid reason I'll update my pull request. but as far as I can tell checking for connected should be enough.