### PR TITLE
Fix case in which x and y are not specified in panning

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -656,9 +656,9 @@ def get_fb_dimensions(configuration):
         if "panning" in output.options:
             match = re.match("(?P<w>[0-9]+)x(?P<h>[0-9]+)(?:\+(?P<x>[0-9]+))?(?:\+(?P<y>[0-9]+))?.*", output.options["panning"])
             if match:
-                detail = match.groupdict()
-                o_width = int(detail.get("w")) + int(detail.get("x", "0"))
-                o_height = int(detail.get("h")) + int(detail.get("y", "0"))
+                detail = match.groupdict(default="0")
+                o_width = int(detail.get("w")) + int(detail.get("x"))
+                o_height = int(detail.get("h")) + int(detail.get("y"))
         width = max(width, o_width)
         height = max(height, o_height)
     return int(width), int(height)


### PR DESCRIPTION
The regular expression that extracts the panning values has optional
matches for the named groups x and y.

Previously, the case in which there is no match for x and y looks to
have been attempted to be handled by doing

  detail.get("x", "0")

This is a bug.  The default argument to dict.get is only returned when
the key is not a member of the dictionary.  However, when a group
fails to participate in the regex match, the dict does have a key.
The default value of this default key is None.  This would lead to an
error when the get returned None and None was then cast to an integer.

This resolves the issue by explicitly setting the groupdict default to
be "0", which is appropriate for the two groups (x and y) that may
optionally participate in the match.