### PR TITLE
Work around problems with autorandr's completion when using `bashcompinit`

### DIFF
--- a/contrib/bash_completion/autorandr
+++ b/contrib/bash_completion/autorandr
@@ -29,9 +29,9 @@ _autorandr ()
 	        AR_DIRS=( "${AR_DIRS[@]}" "${XDG_CONFIG_HOME:-$HOME/.config}/autorandr/" )
 	fi
 
-	if [ -n "${AR_DIRS}" ]
+	if [ "${#AR_DIRS[@]}" -gt 0 ]
 	then
-		prfls="$(find "${AR_DIRS[@]}" -mindepth 1 -maxdepth 1 -type d ! -name "*.d" -printf '%f\n' | sort -u)"
+		prfls="$(find "${AR_DIRS[@]}" -mindepth 1 -maxdepth 1 -type d ! -name "*.d" -printf '%f\n' 2>/dev/null | sort -u)"
 	else
 		prfls=""
 	fi


### PR DESCRIPTION
On ZSH the easiest approach to get bash completions running is to use
`bashcompinit`. Unfortunately it seems as there are slight differences
between ZSH and bash which cause problems when using that feature.

I had to change the following things:

* Replace the `-n` check with a length check of the AR directory array:
  ZSH adds an empty string at first if no system directory for autorandr
  was found. Checking if there's at least a single element works around
  this problem.

* Silence errors from `find`. The empty string at first causes a
  `directory not found error` during the completion.

It can be tested on ZSH after running the following command:

```
$ autoload -U +X bashcompinit && bashcompinit && source ./contrib/bash_completion/autorandr
```

Tested with zsh 5.7.1 (x86_64-pc-linux-gnu).