### PR TITLE
Typo

### DIFF
--- a/autorandr.1
+++ b/autorandr.1
@@ -63,7 +63,7 @@ Show version information and exit
 .br
 See https://github.com/phillipberndt/autorandr for a full list of contributors. 
 .SH REPORTING BUGS
-\fRReport issues upstream on GitHub:  https://githb.com/phillipberndt/autorandr/issues
+\fRReport issues upstream on GitHub:  https://github.com/phillipberndt/autorandr/issues
 .br
 \fRPlease attach the output of \fBxrandr --verbose\fR to your bug report if appropriate.
 .SH SEE ALSO


### PR DESCRIPTION
There's a small typo in the man page, and the link won't work because of it.