### PR TITLE
Call xrandr individually for each display

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -780,8 +780,8 @@ def apply_configuration(new_configuration, current_configuration, dry_run=False)
 
     # Enable the remaining outputs in pairs of two operations
     operations = disable_outputs + enable_outputs
-    for index in range(0, len(operations), 2):
-        argv = base_argv + list(chain.from_iterable(operations[index:index + 2]))
+    for op in operations:
+        argv = base_argv + list(op)
         if call_and_retry(argv, dry_run=dry_run) != 0:
             raise AutorandrException("Command failed: %s" % " ".join(argv))
 


### PR DESCRIPTION
The way autorandr previously used to generate one gigantic `xrandr` call with multiple `--output`s wouldn't work reliably. In some setups, I'd consistently get:

> xrandr: Configure crtc 1 failed"

whereas running two `xrandr` calls, one for each display, works.

This patch simply dispatches one `xrandr` call per display.