### PR TITLE
Treating a closed lid as disconnected

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Contributors to this version of autorandr are:
 * Brice Waegeneire
 * Chris Dunder
 * Christoph Gysin
+* Christophe-Marie Duquesne
 * Daniel Hahler
 * Maciej Sitarz
 * Mathias Svensson

--- a/autorandr.py
+++ b/autorandr.py
@@ -324,7 +324,7 @@ class XrandrOutput(object):
                 raise AutorandrException("Parsing XRandR output failed, couldn't find any display modes", report_bug=True)
 
         options = {}
-        if not match["connected"] or is_closed_lid(match["output"]):
+        if not match["connected"]:
             edid = None
         elif match["edid"]:
             edid = "".join(match["edid"].strip().split())
@@ -517,6 +517,12 @@ def parse_xrandr_output():
         outputs[output_name] = output
         if output_modes:
             modes[output_name] = output_modes
+
+    # consider a closed lid as disconnected if other outputs are connected
+    if sum(o.edid != None for o in outputs.values()) > 1:
+        for output_name in outputs.keys():
+            if is_closed_lid(output_name):
+                outputs[output_name].edid = None
 
     return outputs, modes
 

--- a/contrib/etc/xdg/autostart/autorandr-lid-listener.desktop
+++ b/contrib/etc/xdg/autostart/autorandr-lid-listener.desktop
@@ -2,5 +2,5 @@
 Name=Autorandr Lid Listener
 Comment=Trigger autorandr whenever the lid state changes
 Type=Application
-Exec=bash -c "stdbuf -oL libinput debug-events | grep --line-buffered SWITCH_TOGGLE | while read line; do autorandr --change --default default; done"
+Exec=bash -c "stdbuf -oL libinput debug-events | egrep --line-buffered '^ event[0-9]+\s+SWITCH_TOGGLE\s' | while read line; do autorandr --change --default default; done"
 X-GNOME-Autostart-Phase=Initialization

--- a/contrib/etc/xdg/autostart/autorandr-lid-listener.desktop
+++ b/contrib/etc/xdg/autostart/autorandr-lid-listener.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Autorandr Lid Listener
+Comment=Trigger autorandr whenever the lid state changes
+Type=Application
+Exec=bash -c "stdbuf -oL libinput debug-events | grep --line-buffered SWITCH_TOGGLE | while read line; do autorandr --change --default default; done"
+X-GNOME-Autostart-Phase=Initialization

--- a/contrib/listen_lid.sh
+++ b/contrib/listen_lid.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# /!\ You must be part of the input group
+# sudo gpasswd -a $USER input
+
+libinput debug-events | grep SWITCH_TOGGLE | while read event; do
+    autorandr --change --default default
+done

--- a/contrib/listen_lid.sh
+++ b/contrib/listen_lid.sh
@@ -3,6 +3,8 @@
 # /!\ You must be part of the input group
 # sudo gpasswd -a $USER input
 
-stdbuf -oL libinput debug-events | grep --line-buffered SWITCH_TOGGLE | while read line; do
+stdbuf -oL libinput debug-events | \
+    egrep --line-buffered '^ event[0-9]+\s+SWITCH_TOGGLE\s' | \
+    while read line; do
     autorandr --change --default default
 done

--- a/contrib/listen_lid.sh
+++ b/contrib/listen_lid.sh
@@ -3,6 +3,6 @@
 # /!\ You must be part of the input group
 # sudo gpasswd -a $USER input
 
-libinput debug-events | grep SWITCH_TOGGLE | while read event; do
+stdbuf -oL libinput debug-events | grep --line-buffered SWITCH_TOGGLE | while read line; do
     autorandr --change --default default
 done

--- a/contrib/systemd/autorandr-lid-listener.service
+++ b/contrib/systemd/autorandr-lid-listener.service
@@ -3,7 +3,7 @@ Description=Runs autorandr whenever the lid state changes
 
 [Service]
 Type=simple
-ExecStart=bash -c "stdbuf -oL libinput debug-events | grep --line-buffered SWITCH_TOGGLE | while read line; do autorandr --batch --change --default default; done"
+ExecStart=bash -c "stdbuf -oL libinput debug-events | egrep --line-buffered '^ event[0-9]+\s+SWITCH_TOGGLE\s' | while read line; do autorandr --batch --change --default default; done"
 Restart=always
 RestartSec=30
 SyslogIdentifier=autorandr

--- a/contrib/systemd/autorandr-lid-listener.service
+++ b/contrib/systemd/autorandr-lid-listener.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Runs autorandr whenever the lid state changes
+
+[Service]
+Type=simple
+ExecStart=bash -c "stdbuf -oL libinput debug-events | grep --line-buffered SWITCH_TOGGLE | while read line; do autorandr --batch --change --default default; done"
+Restart=always
+RestartSec=30
+SyslogIdentifier=autorandr
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR tries to solve #104 

The idea is to detect if the xrandr output is a laptop lid, and then to find out whether it is open or closed. Here is how the logic works:

* A lid is either named eDP or LVDS, possibly followed by some number. I got this logic from looking at how xrandr [generates](http://www.thinkwiki.org/wiki/Xorg_RandR_1.2#Output_port_names) the [output](https://github.com/freedesktop/xorg-xf86-video-intel/blob/c6cb1b199598c572484fb4e30e1026be9d4ccc31/src/uxa/intel_display.c#L767) [names](https://github.com/freedesktop/xorg-xf86-video-ati/blob/4407c78bd86da4460ee07a15a365e07d99e0dd27/src/drmmode_display.c#L2005).
* If it's a lid, it has a state, in `/proc/acpi/button/lid/*/state`. We look in there to know whether it is open or closed.

I am making the assumption that there is exactly one file found under `/proc/acpi/button/lid/*/state`. If this is not true, it is assumed that the xrandr output is not a lid.

Feel free to test and to merge if you like it.

