### PR TITLE
regexp and shell

### DIFF
--- a/contrib/listen_lid.sh
+++ b/contrib/listen_lid.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 #
 # /!\ You must be part of the input group
 # sudo gpasswd -a $USER input
 
 stdbuf -oL libinput debug-events | \
-    egrep --line-buffered '^ event[0-9]+\s+SWITCH_TOGGLE\s' | \
+    egrep --line-buffered '^[\s-]+event[0-9]+\s+SWITCH_TOGGLE\s' | \
     while read line; do
     autorandr --change --default default
 done

--- a/contrib/systemd/autorandr-lid-listener.service
+++ b/contrib/systemd/autorandr-lid-listener.service
@@ -3,7 +3,7 @@ Description=Runs autorandr whenever the lid state changes
 
 [Service]
 Type=simple
-ExecStart=bash -c "stdbuf -oL libinput debug-events | egrep --line-buffered '^ event[0-9]+\s+SWITCH_TOGGLE\s' | while read line; do autorandr --batch --change --default default; done"
+ExecStart=sh -c "stdbuf -oL libinput debug-events | egrep --line-buffered '^[\s-]+event[0-9]+\s+SWITCH_TOGGLE\s' | while read line; do autorandr --batch --change --default default; done"
 Restart=always
 RestartSec=30
 SyslogIdentifier=autorandr


### PR DESCRIPTION
Sometimes `libinput debug` prints dash-prefixed events, usually if some other button was pressed just before lid event, old regexp missed those.

Secondly, no need for heavy artillery here, so switch to simple `sh`