### PR TITLE
Further fixes

### DIFF
--- a/contrib/listen_lid.sh
+++ b/contrib/listen_lid.sh
@@ -4,7 +4,7 @@
 # sudo gpasswd -a $USER input
 
 stdbuf -oL libinput debug-events | \
-    egrep --line-buffered '^[[:space:]-]+event[0-9]+\s+SWITCH_TOGGLE\s' | \
+    grep -E --line-buffered '^[[:space:]-]+event[0-9]+[[:space:]]+SWITCH_TOGGLE[[:space:]]' | \
     while read line; do
     autorandr --change --default default
 done

--- a/contrib/listen_lid.sh
+++ b/contrib/listen_lid.sh
@@ -4,7 +4,7 @@
 # sudo gpasswd -a $USER input
 
 stdbuf -oL libinput debug-events | \
-    egrep --line-buffered '^[\s-]+event[0-9]+\s+SWITCH_TOGGLE\s' | \
+    egrep --line-buffered '^[[:space:]-]+event[0-9]+\s+SWITCH_TOGGLE\s' | \
     while read line; do
     autorandr --change --default default
 done

--- a/contrib/systemd/autorandr-lid-listener.service
+++ b/contrib/systemd/autorandr-lid-listener.service
@@ -3,7 +3,7 @@ Description=Runs autorandr whenever the lid state changes
 
 [Service]
 Type=simple
-ExecStart=sh -c "stdbuf -oL libinput debug-events | egrep --line-buffered '^[\s-]+event[0-9]+\s+SWITCH_TOGGLE\s' | while read line; do autorandr --batch --change --default default; done"
+ExecStart=sh -c "stdbuf -oL libinput debug-events | egrep --line-buffered '^[[:space:]-]+event[0-9]+\\s+SWITCH_TOGGLE\\s' | while read line; do autorandr --batch --change --default default; done"
 Restart=always
 RestartSec=30
 SyslogIdentifier=autorandr

--- a/contrib/systemd/autorandr-lid-listener.service
+++ b/contrib/systemd/autorandr-lid-listener.service
@@ -3,7 +3,7 @@ Description=Runs autorandr whenever the lid state changes
 
 [Service]
 Type=simple
-ExecStart=sh -c "stdbuf -oL libinput debug-events | egrep --line-buffered '^[[:space:]-]+event[0-9]+\\s+SWITCH_TOGGLE\\s' | while read line; do autorandr --batch --change --default default; done"
+ExecStart=sh -c "stdbuf -oL libinput debug-events | grep -E --line-buffered '^[[:space:]-]+event[0-9]+[[:space:]]+SWITCH_TOGGLE[[:space:]]' | while read line; do autorandr --batch --change --default default; done"
 Restart=always
 RestartSec=30
 SyslogIdentifier=autorandr


### PR DESCRIPTION
It appears that `\s` didn't work inside brackets, and `egrep` is deprecated according to manpage. So, I did it by the book.