### PR TITLE
Ignore negative gamma values

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -173,7 +173,7 @@ class XrandrOutput(object):
         (?:[\ \t]*tracking\ (?P<tracking>[0-9]+x[0-9]+\+[0-9]+\+[0-9]+))?               # Tracking information
         (?:[\ \t]*border\ (?P<border>(?:[0-9]+/){3}[0-9]+))?                            # Border information
         (?:\s*(?:                                                                       # Properties of the output
-            Gamma: (?P<gamma>(?:inf|[0-9\.: e])+) |                                     # Gamma value
+            Gamma: (?P<gamma>(?:inf|[0-9\.\-: e])+) |                                   # Gamma value
             CRTC:\s*(?P<crtc>[0-9]) |                                                   # CRTC value
             Transform: (?P<transform>(?:[\-0-9\. ]+\s+){3}) |                           # Transformation matrix
             EDID: (?P<edid>\s*?(?:\\n\\t\\t[0-9a-f]+)+) |                               # EDID of the output


### PR DESCRIPTION
` xrandr` sometimes mysteriously reports a negative gamma for my external monitor, causing `autorandr` to fail (meaning that my laptop won't switch over to the external monitor). I suspect redshift may be to blame, but I can't prove it :shrug:. 

According to this 
https://github.com/phillipberndt/autorandr/blob/ad32e62cd99060b7398dd5bbe02f2f88f62df256/autorandr.py#L384-L386
a negative value will just end up as `1e-10` so I'm guessing it'd be fine to change the regex to accept negative gammas. 


### output
Just for fun, here's an example of my weird `xrandr --verbose` output (see `DP-1-8` below)
```
Screen 0: minimum 320 x 200, current 3840 x 2160, maximum 16384 x 16384
eDP-1 connected primary 3840x2160+0+0 (0x46) normal (normal left inverted right x axis y axis) 294mm x 165mm
	Identifier: 0x42
	Timestamp:  160592520
	Subpixel:   unknown
	Gamma:      1.0:1.0:1.0
	Brightness: 1.0
	Clones:    
	CRTC:       0
	CRTCs:      0 1 2
	Transform:  1.000000 0.000000 0.000000
	            0.000000 1.000000 0.000000
	            0.000000 0.000000 1.000000
	           filter: 
	EDID: 
		00ffffffffffff004d10ad1400000000
		2a1c0104a51d11780ede50a3544c9926
		0f505400000001010101010101010101
		0101010101014dd000a0f0703e803020
		350026a510000018a4a600a0f0703e80
		3020350026a510000018000000fe0030
		5239394b804c51313333443100000000
		0002410328011200000b010a20200041
	scaling mode: Full aspect 
		supported: Full, Center, Full aspect
	max bpc: 12 
		range: (6, 12)
	Broadcast RGB: Automatic 
		supported: Automatic, Full, Limited 16:235
	link-status: Good 
		supported: Good, Bad
	CONNECTOR_ID: 86 
		supported: 86
	non-desktop: 0 
		range: (0, 1)
  3840x2160 (0x46) 533.250MHz -HSync -VSync *current +preferred
        h: width  3840 start 3888 end 3920 total 4000 skew    0 clock 133.31KHz
        v: height 2160 start 2163 end 2168 total 2222           clock  60.00Hz
  3840x2160 (0x47) 712.750MHz -HSync +VSync
        h: width  3840 start 4160 end 4576 total 5312 skew    0 clock 134.18KHz
        v: height 2160 start 2163 end 2168 total 2237           clock  59.98Hz
  3840x2160 (0x48) 533.000MHz +HSync -VSync
        h: width  3840 start 3888 end 3920 total 4000 skew    0 clock 133.25KHz
        v: height 2160 start 2163 end 2168 total 2222           clock  59.97Hz
  3840x2160 (0x49) 426.600MHz -HSync -VSync
        h: width  3840 start 3888 end 3920 total 4000 skew    0 clock 106.65KHz
        v: height 2160 start 2163 end 2168 total 2222           clock  48.00Hz
  3200x1800 (0x4a) 492.000MHz -HSync +VSync
        h: width  3200 start 3456 end 3800 total 4400 skew    0 clock 111.82KHz
        v: height 1800 start 1803 end 1808 total 1865           clock  59.96Hz
  3200x1800 (0x4b) 373.000MHz +HSync -VSync
        h: width  3200 start 3248 end 3280 total 3360 skew    0 clock 111.01KHz
        v: height 1800 start 1803 end 1808 total 1852           clock  59.94Hz
  2880x1620 (0x4c) 396.250MHz -HSync +VSync
        h: width  2880 start 3096 end 3408 total 3936 skew    0 clock 100.67KHz
        v: height 1620 start 1623 end 1628 total 1679           clock  59.96Hz
  2880x1620 (0x4d) 303.750MHz +HSync -VSync
        h: width  2880 start 2928 end 2960 total 3040 skew    0 clock  99.92KHz
        v: height 1620 start 1623 end 1628 total 1666           clock  59.97Hz
  2560x1600 (0x4e) 348.500MHz -HSync +VSync
        h: width  2560 start 2760 end 3032 total 3504 skew    0 clock  99.46KHz
        v: height 1600 start 1603 end 1609 total 1658           clock  59.99Hz
  2560x1600 (0x4f) 268.500MHz +HSync -VSync
        h: width  2560 start 2608 end 2640 total 2720 skew    0 clock  98.71KHz
        v: height 1600 start 1603 end 1609 total 1646           clock  59.97Hz
  2560x1440 (0x50) 638.250MHz -HSync +VSync DoubleScan
        h: width  2560 start 2780 end 3064 total 3568 skew    0 clock 178.88KHz
        v: height 1440 start 1441 end 1444 total 1491           clock  59.99Hz
  2560x1440 (0x51) 469.125MHz +HSync -VSync DoubleScan
        h: width  2560 start 2584 end 2600 total 2640 skew    0 clock 177.70KHz
        v: height 1440 start 1441 end 1444 total 1481           clock  59.99Hz
  2560x1440 (0x52) 312.250MHz -HSync +VSync
        h: width  2560 start 2752 end 3024 total 3488 skew    0 clock  89.52KHz
        v: height 1440 start 1443 end 1448 total 1493           clock  59.96Hz
  2560x1440 (0x53) 241.500MHz +HSync -VSync
        h: width  2560 start 2608 end 2640 total 2720 skew    0 clock  88.79KHz
        v: height 1440 start 1443 end 1448 total 1481           clock  59.95Hz
  2048x1536 (0x54) 266.950MHz -HSync +VSync
        h: width  2048 start 2200 end 2424 total 2800 skew    0 clock  95.34KHz
        v: height 1536 start 1537 end 1540 total 1589           clock  60.00Hz
  1920x1440 (0x55) 234.000MHz -HSync +VSync
        h: width  1920 start 2048 end 2256 total 2600 skew    0 clock  90.00KHz
        v: height 1440 start 1441 end 1444 total 1500           clock  60.00Hz
  1856x1392 (0x56) 218.300MHz -HSync +VSync
        h: width  1856 start 1952 end 2176 total 2528 skew    0 clock  86.35KHz
        v: height 1392 start 1393 end 1396 total 1439           clock  60.01Hz
  1792x1344 (0x57) 204.800MHz -HSync +VSync
        h: width  1792 start 1920 end 2120 total 2448 skew    0 clock  83.66KHz
        v: height 1344 start 1345 end 1348 total 1394           clock  60.01Hz
  2048x1152 (0x58) 406.500MHz -HSync +VSync DoubleScan
        h: width  2048 start 2220 end 2444 total 2840 skew    0 clock 143.13KHz
        v: height 1152 start 1153 end 1156 total 1193           clock  59.99Hz
  2048x1152 (0x59) 302.500MHz +HSync -VSync DoubleScan
        h: width  2048 start 2072 end 2088 total 2128 skew    0 clock 142.15KHz
        v: height 1152 start 1153 end 1156 total 1185           clock  59.98Hz
  2048x1152 (0x5a) 197.000MHz -HSync +VSync
        h: width  2048 start 2184 end 2400 total 2752 skew    0 clock  71.58KHz
        v: height 1152 start 1155 end 1160 total 1195           clock  59.90Hz
  2048x1152 (0x5b) 156.750MHz +HSync -VSync
        h: width  2048 start 2096 end 2128 total 2208 skew    0 clock  70.99KHz
        v: height 1152 start 1155 end 1160 total 1185           clock  59.91Hz
  1920x1200 (0x5c) 193.250MHz -HSync +VSync
        h: width  1920 start 2056 end 2256 total 2592 skew    0 clock  74.56KHz
        v: height 1200 start 1203 end 1209 total 1245           clock  59.88Hz
  1920x1200 (0x5d) 154.000MHz +HSync -VSync
        h: width  1920 start 1968 end 2000 total 2080 skew    0 clock  74.04KHz
        v: height 1200 start 1203 end 1209 total 1235           clock  59.95Hz
  1920x1080 (0x5e) 356.375MHz -HSync +VSync DoubleScan
        h: width  1920 start 2080 end 2288 total 2656 skew    0 clock 134.18KHz
        v: height 1080 start 1081 end 1084 total 1118           clock  60.01Hz
  1920x1080 (0x5f) 266.500MHz +HSync -VSync DoubleScan
        h: width  1920 start 1944 end 1960 total 2000 skew    0 clock 133.25KHz
        v: height 1080 start 1081 end 1084 total 1111           clock  59.97Hz
  1920x1080 (0x60) 173.000MHz -HSync +VSync
        h: width  1920 start 2048 end 2248 total 2576 skew    0 clock  67.16KHz
        v: height 1080 start 1083 end 1088 total 1120           clock  59.96Hz
  1920x1080 (0x61) 138.500MHz +HSync -VSync
        h: width  1920 start 1968 end 2000 total 2080 skew    0 clock  66.59KHz
        v: height 1080 start 1083 end 1088 total 1111           clock  59.93Hz
  1600x1200 (0x62) 162.000MHz +HSync +VSync
        h: width  1600 start 1664 end 1856 total 2160 skew    0 clock  75.00KHz
        v: height 1200 start 1201 end 1204 total 1250           clock  60.00Hz
  1680x1050 (0x63) 146.250MHz -HSync +VSync
        h: width  1680 start 1784 end 1960 total 2240 skew    0 clock  65.29KHz
        v: height 1050 start 1053 end 1059 total 1089           clock  59.95Hz
  1680x1050 (0x64) 119.000MHz +HSync -VSync
        h: width  1680 start 1728 end 1760 total 1840 skew    0 clock  64.67KHz
        v: height 1050 start 1053 end 1059 total 1080           clock  59.88Hz
  1400x1050 (0x65) 122.000MHz +HSync +VSync
        h: width  1400 start 1488 end 1640 total 1880 skew    0 clock  64.89KHz
        v: height 1050 start 1052 end 1064 total 1082           clock  59.98Hz
  1600x900 (0x66) 246.000MHz -HSync +VSync DoubleScan
        h: width  1600 start 1728 end 1900 total 2200 skew    0 clock 111.82KHz
        v: height  900 start  901 end  904 total  932           clock  59.99Hz
  1600x900 (0x67) 186.500MHz +HSync -VSync DoubleScan
        h: width  1600 start 1624 end 1640 total 1680 skew    0 clock 111.01KHz
        v: height  900 start  901 end  904 total  926           clock  59.94Hz
  1600x900 (0x68) 118.250MHz -HSync +VSync
        h: width  1600 start 1696 end 1856 total 2112 skew    0 clock  55.99KHz
        v: height  900 start  903 end  908 total  934           clock  59.95Hz
  1600x900 (0x69) 97.500MHz +HSync -VSync
        h: width  1600 start 1648 end 1680 total 1760 skew    0 clock  55.40KHz
        v: height  900 start  903 end  908 total  926           clock  59.82Hz
  1280x1024 (0x6a) 108.000MHz +HSync +VSync
        h: width  1280 start 1328 end 1440 total 1688 skew    0 clock  63.98KHz
        v: height 1024 start 1025 end 1028 total 1066           clock  60.02Hz
  1400x900 (0x6b) 103.500MHz -HSync +VSync
        h: width  1400 start 1480 end 1624 total 1848 skew    0 clock  56.01KHz
        v: height  900 start  903 end  913 total  934           clock  59.96Hz
  1400x900 (0x6c) 86.500MHz +HSync -VSync
        h: width  1400 start 1448 end 1480 total 1560 skew    0 clock  55.45KHz
        v: height  900 start  903 end  913 total  926           clock  59.88Hz
  1280x960 (0x6d) 108.000MHz +HSync +VSync
        h: width  1280 start 1376 end 1488 total 1800 skew    0 clock  60.00KHz
        v: height  960 start  961 end  964 total 1000           clock  60.00Hz
  1440x810 (0x6e) 198.125MHz -HSync +VSync DoubleScan
        h: width  1440 start 1548 end 1704 total 1968 skew    0 clock 100.67KHz
        v: height  810 start  811 end  814 total  839           clock  60.00Hz
  1440x810 (0x6f) 151.875MHz +HSync -VSync DoubleScan
        h: width  1440 start 1464 end 1480 total 1520 skew    0 clock  99.92KHz
        v: height  810 start  811 end  814 total  833           clock  59.97Hz
  1368x768 (0x70) 85.250MHz -HSync +VSync
        h: width  1368 start 1440 end 1576 total 1784 skew    0 clock  47.79KHz
        v: height  768 start  771 end  781 total  798           clock  59.88Hz
  1368x768 (0x71) 72.250MHz +HSync -VSync
        h: width  1368 start 1416 end 1448 total 1528 skew    0 clock  47.28KHz
        v: height  768 start  771 end  781 total  790           clock  59.85Hz
  1280x800 (0x72) 174.250MHz -HSync +VSync DoubleScan
        h: width  1280 start 1380 end 1516 total 1752 skew    0 clock  99.46KHz
        v: height  800 start  801 end  804 total  829           clock  59.99Hz
  1280x800 (0x73) 134.250MHz +HSync -VSync DoubleScan
        h: width  1280 start 1304 end 1320 total 1360 skew    0 clock  98.71KHz
        v: height  800 start  801 end  804 total  823           clock  59.97Hz
  1280x800 (0x74) 83.500MHz -HSync +VSync
        h: width  1280 start 1352 end 1480 total 1680 skew    0 clock  49.70KHz
        v: height  800 start  803 end  809 total  831           clock  59.81Hz
  1280x800 (0x75) 71.000MHz +HSync -VSync
        h: width  1280 start 1328 end 1360 total 1440 skew    0 clock  49.31KHz
        v: height  800 start  803 end  809 total  823           clock  59.91Hz
  1280x720 (0x76) 156.125MHz -HSync +VSync DoubleScan
        h: width  1280 start 1376 end 1512 total 1744 skew    0 clock  89.52KHz
        v: height  720 start  721 end  724 total  746           clock  60.00Hz
  1280x720 (0x77) 120.750MHz +HSync -VSync DoubleScan
        h: width  1280 start 1304 end 1320 total 1360 skew    0 clock  88.79KHz
        v: height  720 start  721 end  724 total  740           clock  59.99Hz
  1280x720 (0x78) 74.500MHz -HSync +VSync
        h: width  1280 start 1344 end 1472 total 1664 skew    0 clock  44.77KHz
        v: height  720 start  723 end  728 total  748           clock  59.86Hz
  1280x720 (0x79) 63.750MHz +HSync -VSync
        h: width  1280 start 1328 end 1360 total 1440 skew    0 clock  44.27KHz
        v: height  720 start  723 end  728 total  741           clock  59.74Hz
  1024x768 (0x7a) 133.475MHz -HSync +VSync DoubleScan
        h: width  1024 start 1100 end 1212 total 1400 skew    0 clock  95.34KHz
        v: height  768 start  768 end  770 total  794           clock  60.04Hz
  1024x768 (0x7b) 65.000MHz -HSync -VSync
        h: width  1024 start 1048 end 1184 total 1344 skew    0 clock  48.36KHz
        v: height  768 start  771 end  777 total  806           clock  60.00Hz
  960x720 (0x7c) 117.000MHz -HSync +VSync DoubleScan
        h: width   960 start 1024 end 1128 total 1300 skew    0 clock  90.00KHz
        v: height  720 start  720 end  722 total  750           clock  60.00Hz
  928x696 (0x7d) 109.150MHz -HSync +VSync DoubleScan
        h: width   928 start  976 end 1088 total 1264 skew    0 clock  86.35KHz
        v: height  696 start  696 end  698 total  719           clock  60.05Hz
  896x672 (0x7e) 102.400MHz -HSync +VSync DoubleScan
        h: width   896 start  960 end 1060 total 1224 skew    0 clock  83.66KHz
        v: height  672 start  672 end  674 total  697           clock  60.01Hz
  1024x576 (0x7f) 98.500MHz -HSync +VSync DoubleScan
        h: width  1024 start 1092 end 1200 total 1376 skew    0 clock  71.58KHz
        v: height  576 start  577 end  580 total  597           clock  59.95Hz
  1024x576 (0x80) 78.375MHz +HSync -VSync DoubleScan
        h: width  1024 start 1048 end 1064 total 1104 skew    0 clock  70.99KHz
        v: height  576 start  577 end  580 total  592           clock  59.96Hz
  1024x576 (0x81) 46.500MHz -HSync +VSync
        h: width  1024 start 1064 end 1160 total 1296 skew    0 clock  35.88KHz
        v: height  576 start  579 end  584 total  599           clock  59.90Hz
  1024x576 (0x82) 42.000MHz +HSync -VSync
        h: width  1024 start 1072 end 1104 total 1184 skew    0 clock  35.47KHz
        v: height  576 start  579 end  584 total  593           clock  59.82Hz
  960x600 (0x83) 96.625MHz -HSync +VSync DoubleScan
        h: width   960 start 1028 end 1128 total 1296 skew    0 clock  74.56KHz
        v: height  600 start  601 end  604 total  622           clock  59.93Hz
  960x600 (0x84) 77.000MHz +HSync -VSync DoubleScan
        h: width   960 start  984 end 1000 total 1040 skew    0 clock  74.04KHz
        v: height  600 start  601 end  604 total  617           clock  60.00Hz
  960x540 (0x85) 86.500MHz -HSync +VSync DoubleScan
        h: width   960 start 1024 end 1124 total 1288 skew    0 clock  67.16KHz
        v: height  540 start  541 end  544 total  560           clock  59.96Hz
  960x540 (0x86) 69.250MHz +HSync -VSync DoubleScan
        h: width   960 start  984 end 1000 total 1040 skew    0 clock  66.59KHz
        v: height  540 start  541 end  544 total  555           clock  59.99Hz
  960x540 (0x87) 40.750MHz -HSync +VSync
        h: width   960 start  992 end 1088 total 1216 skew    0 clock  33.51KHz
        v: height  540 start  543 end  548 total  562           clock  59.63Hz
  960x540 (0x88) 37.250MHz +HSync -VSync
        h: width   960 start 1008 end 1040 total 1120 skew    0 clock  33.26KHz
        v: height  540 start  543 end  548 total  556           clock  59.82Hz
  800x600 (0x89) 81.000MHz +HSync +VSync DoubleScan
        h: width   800 start  832 end  928 total 1080 skew    0 clock  75.00KHz
        v: height  600 start  600 end  602 total  625           clock  60.00Hz
  800x600 (0x8a) 40.000MHz +HSync +VSync
        h: width   800 start  840 end  968 total 1056 skew    0 clock  37.88KHz
        v: height  600 start  601 end  605 total  628           clock  60.32Hz
  800x600 (0x8b) 36.000MHz +HSync +VSync
        h: width   800 start  824 end  896 total 1024 skew    0 clock  35.16KHz
        v: height  600 start  601 end  603 total  625           clock  56.25Hz
  840x525 (0x8c) 73.125MHz -HSync +VSync DoubleScan
        h: width   840 start  892 end  980 total 1120 skew    0 clock  65.29KHz
        v: height  525 start  526 end  529 total  544           clock  60.01Hz
  840x525 (0x8d) 59.500MHz +HSync -VSync DoubleScan
        h: width   840 start  864 end  880 total  920 skew    0 clock  64.67KHz
        v: height  525 start  526 end  529 total  540           clock  59.88Hz
  864x486 (0x8e) 32.500MHz -HSync +VSync
        h: width   864 start  888 end  968 total 1072 skew    0 clock  30.32KHz
        v: height  486 start  489 end  494 total  506           clock  59.92Hz
  864x486 (0x8f) 30.500MHz +HSync -VSync
        h: width   864 start  912 end  944 total 1024 skew    0 clock  29.79KHz
        v: height  486 start  489 end  494 total  500           clock  59.57Hz
  700x525 (0x90) 61.000MHz +HSync +VSync DoubleScan
        h: width   700 start  744 end  820 total  940 skew    0 clock  64.89KHz
        v: height  525 start  526 end  532 total  541           clock  59.98Hz
  800x450 (0x91) 59.125MHz -HSync +VSync DoubleScan
        h: width   800 start  848 end  928 total 1056 skew    0 clock  55.99KHz
        v: height  450 start  451 end  454 total  467           clock  59.95Hz
  800x450 (0x92) 48.750MHz +HSync -VSync DoubleScan
        h: width   800 start  824 end  840 total  880 skew    0 clock  55.40KHz
        v: height  450 start  451 end  454 total  463           clock  59.82Hz
  640x512 (0x93) 54.000MHz +HSync +VSync DoubleScan
        h: width   640 start  664 end  720 total  844 skew    0 clock  63.98KHz
        v: height  512 start  512 end  514 total  533           clock  60.02Hz
  700x450 (0x94) 51.750MHz -HSync +VSync DoubleScan
        h: width   700 start  740 end  812 total  924 skew    0 clock  56.01KHz
        v: height  450 start  451 end  456 total  467           clock  59.96Hz
  700x450 (0x95) 43.250MHz +HSync -VSync DoubleScan
        h: width   700 start  724 end  740 total  780 skew    0 clock  55.45KHz
        v: height  450 start  451 end  456 total  463           clock  59.88Hz
  640x480 (0x96) 54.000MHz +HSync +VSync DoubleScan
        h: width   640 start  688 end  744 total  900 skew    0 clock  60.00KHz
        v: height  480 start  480 end  482 total  500           clock  60.00Hz
  640x480 (0x97) 25.175MHz -HSync -VSync
        h: width   640 start  656 end  752 total  800 skew    0 clock  31.47KHz
        v: height  480 start  490 end  492 total  525           clock  59.94Hz
  720x405 (0x98) 22.500MHz -HSync +VSync
        h: width   720 start  744 end  808 total  896 skew    0 clock  25.11KHz
        v: height  405 start  408 end  413 total  422           clock  59.51Hz
  720x405 (0x99) 21.750MHz +HSync -VSync
        h: width   720 start  768 end  800 total  880 skew    0 clock  24.72KHz
        v: height  405 start  408 end  413 total  419           clock  58.99Hz
  684x384 (0x9a) 42.625MHz -HSync +VSync DoubleScan
        h: width   684 start  720 end  788 total  892 skew    0 clock  47.79KHz
        v: height  384 start  385 end  390 total  399           clock  59.88Hz
  684x384 (0x9b) 36.125MHz +HSync -VSync DoubleScan
        h: width   684 start  708 end  724 total  764 skew    0 clock  47.28KHz
        v: height  384 start  385 end  390 total  395           clock  59.85Hz
  640x400 (0x9c) 41.750MHz -HSync +VSync DoubleScan
        h: width   640 start  676 end  740 total  840 skew    0 clock  49.70KHz
        v: height  400 start  401 end  404 total  415           clock  59.88Hz
  640x400 (0x9d) 35.500MHz +HSync -VSync DoubleScan
        h: width   640 start  664 end  680 total  720 skew    0 clock  49.31KHz
        v: height  400 start  401 end  404 total  411           clock  59.98Hz
  640x360 (0x9e) 37.250MHz -HSync +VSync DoubleScan
        h: width   640 start  672 end  736 total  832 skew    0 clock  44.77KHz
        v: height  360 start  361 end  364 total  374           clock  59.86Hz
  640x360 (0x9f) 31.875MHz +HSync -VSync DoubleScan
        h: width   640 start  664 end  680 total  720 skew    0 clock  44.27KHz
        v: height  360 start  361 end  364 total  370           clock  59.83Hz
  640x360 (0xa0) 18.000MHz -HSync +VSync
        h: width   640 start  664 end  720 total  800 skew    0 clock  22.50KHz
        v: height  360 start  363 end  368 total  376           clock  59.84Hz
  640x360 (0xa1) 17.750MHz +HSync -VSync
        h: width   640 start  688 end  720 total  800 skew    0 clock  22.19KHz
        v: height  360 start  363 end  368 total  374           clock  59.32Hz
  512x384 (0xa2) 32.500MHz -HSync -VSync DoubleScan
        h: width   512 start  524 end  592 total  672 skew    0 clock  48.36KHz
        v: height  384 start  385 end  388 total  403           clock  60.00Hz
  512x288 (0xa3) 23.250MHz -HSync +VSync DoubleScan
        h: width   512 start  532 end  580 total  648 skew    0 clock  35.88KHz
        v: height  288 start  289 end  292 total  299           clock  60.00Hz
  512x288 (0xa4) 21.000MHz +HSync -VSync DoubleScan
        h: width   512 start  536 end  552 total  592 skew    0 clock  35.47KHz
        v: height  288 start  289 end  292 total  296           clock  59.92Hz
  480x270 (0xa5) 20.375MHz -HSync +VSync DoubleScan
        h: width   480 start  496 end  544 total  608 skew    0 clock  33.51KHz
        v: height  270 start  271 end  274 total  281           clock  59.63Hz
  480x270 (0xa6) 18.625MHz +HSync -VSync DoubleScan
        h: width   480 start  504 end  520 total  560 skew    0 clock  33.26KHz
        v: height  270 start  271 end  274 total  278           clock  59.82Hz
  400x300 (0xa7) 20.000MHz +HSync +VSync DoubleScan
        h: width   400 start  420 end  484 total  528 skew    0 clock  37.88KHz
        v: height  300 start  300 end  302 total  314           clock  60.32Hz
  400x300 (0xa8) 18.000MHz +HSync +VSync DoubleScan
        h: width   400 start  412 end  448 total  512 skew    0 clock  35.16KHz
        v: height  300 start  300 end  301 total  312           clock  56.34Hz
  432x243 (0xa9) 16.250MHz -HSync +VSync DoubleScan
        h: width   432 start  444 end  484 total  536 skew    0 clock  30.32KHz
        v: height  243 start  244 end  247 total  253           clock  59.92Hz
  432x243 (0xaa) 15.250MHz +HSync -VSync DoubleScan
        h: width   432 start  456 end  472 total  512 skew    0 clock  29.79KHz
        v: height  243 start  244 end  247 total  250           clock  59.57Hz
  320x240 (0xab) 12.587MHz -HSync -VSync DoubleScan
        h: width   320 start  328 end  376 total  400 skew    0 clock  31.47KHz
        v: height  240 start  245 end  246 total  262           clock  60.05Hz
  360x202 (0xac) 11.250MHz -HSync +VSync DoubleScan
        h: width   360 start  372 end  404 total  448 skew    0 clock  25.11KHz
        v: height  202 start  204 end  206 total  211           clock  59.51Hz
  360x202 (0xad) 10.875MHz +HSync -VSync DoubleScan
        h: width   360 start  384 end  400 total  440 skew    0 clock  24.72KHz
        v: height  202 start  204 end  206 total  209           clock  59.13Hz
  320x180 (0xae)  9.000MHz -HSync +VSync DoubleScan
        h: width   320 start  332 end  360 total  400 skew    0 clock  22.50KHz
        v: height  180 start  181 end  184 total  188           clock  59.84Hz
  320x180 (0xaf)  8.875MHz +HSync -VSync DoubleScan
        h: width   320 start  344 end  360 total  400 skew    0 clock  22.19KHz
        v: height  180 start  181 end  184 total  187           clock  59.32Hz
DP-1 disconnected (normal left inverted right x axis y axis)
	Identifier: 0x43
	Timestamp:  160592520
	Subpixel:   unknown
	Clones:    
	CRTCs:      0 1 2
	Transform:  1.000000 0.000000 0.000000
	            0.000000 1.000000 0.000000
	            0.000000 0.000000 1.000000
	           filter: 
	Content Protection: Undesired 
		supported: Undesired, Desired, Enabled
	max bpc: 12 
		range: (6, 12)
	Broadcast RGB: Automatic 
		supported: Automatic, Full, Limited 16:235
	audio: auto 
		supported: force-dvi, off, auto, on
	link-status: Good 
		supported: Good, Bad
	CONNECTOR_ID: 92 
		supported: 92
	non-desktop: 0 
		range: (0, 1)
DP-2 disconnected (normal left inverted right x axis y axis)
	Identifier: 0x44
	Timestamp:  160592520
	Subpixel:   unknown
	Clones:    
	CRTCs:      0 1 2
	Transform:  1.000000 0.000000 0.000000
	            0.000000 1.000000 0.000000
	            0.000000 0.000000 1.000000
	           filter: 
	Content Protection: Undesired 
		supported: Undesired, Desired, Enabled
	max bpc: 12 
		range: (6, 12)
	Broadcast RGB: Automatic 
		supported: Automatic, Full, Limited 16:235
	audio: auto 
		supported: force-dvi, off, auto, on
	link-status: Good 
		supported: Good, Bad
	CONNECTOR_ID: 100 
		supported: 100
	non-desktop: 0 
		range: (0, 1)
DP-1-8 connected 2560x1440+0+0 (0x53) normal (normal left inverted right x axis y axis) 527mm x 296mm
	Identifier: 0x1b4
	Timestamp:  160592520
	Subpixel:   unknown
	Gamma:      -0.22:1.0:4.1
	Brightness: 0.43
	Clones:    
	CRTC:       1
	CRTCs:      0 1 2
	Transform:  1.000000 0.000000 0.000000
	            0.000000 1.000000 0.000000
	            0.000000 0.000000 1.000000
	           filter: 
	EDID: 
		00ffffffffffff0030aeae6101010101
		181d0104a5351e78180e35a4544d9d26
		0f5054a1080081809500a9c0b300d1c0
		d10001010101565e00a0a0a029503020
		35000f282100001a000000ff0056544c
		30343138380a20202020000000fd0031
		4c1e701e000a202020202020000000fc
		00503234682d31300a202020202001c9
		02031cf04901020304051413101f2309
		0707830100006547e0000400011d0072
		51d01e206e2855000f282100001f8c0a
		d08a20e02d10103e96000f2821000019
		00000000000000000000000000000000
		00000000000000000000000000000000
		00000000000000000000000000000000
		00000000000000000000000000000020
	non-desktop: 0 
		supported: 0, 1
  2560x1440 (0x53) 241.500MHz +HSync -VSync *current +preferred
        h: width  2560 start 2608 end 2640 total 2720 skew    0 clock  88.79KHz
        v: height 1440 start 1443 end 1448 total 1481           clock  59.95Hz
  1920x1200 (0x5c) 193.250MHz -HSync +VSync
        h: width  1920 start 2056 end 2256 total 2592 skew    0 clock  74.56KHz
        v: height 1200 start 1203 end 1209 total 1245           clock  59.88Hz
  1920x1080 (0x1b6) 148.500MHz -HSync -VSync
        h: width  1920 start 2008 end 2052 total 2200 skew    0 clock  67.50KHz
        v: height 1080 start 1084 end 1089 total 1125           clock  60.00Hz
  1920x1080 (0x1b7) 148.500MHz +HSync +VSync
        h: width  1920 start 2008 end 2052 total 2200 skew    0 clock  67.50KHz
        v: height 1080 start 1084 end 1089 total 1125           clock  60.00Hz
  1920x1080 (0x1b8) 148.500MHz +HSync +VSync
        h: width  1920 start 2448 end 2492 total 2640 skew    0 clock  56.25KHz
        v: height 1080 start 1084 end 1089 total 1125           clock  50.00Hz
  1920x1080 (0x1b9) 148.352MHz +HSync +VSync
        h: width  1920 start 2008 end 2052 total 2200 skew    0 clock  67.43KHz
        v: height 1080 start 1084 end 1089 total 1125           clock  59.94Hz
  1680x1050 (0x63) 146.250MHz -HSync +VSync
        h: width  1680 start 1784 end 1960 total 2240 skew    0 clock  65.29KHz
        v: height 1050 start 1053 end 1059 total 1089           clock  59.95Hz
  1600x900 (0x1ba) 108.000MHz +HSync +VSync
        h: width  1600 start 1624 end 1704 total 1800 skew    0 clock  60.00KHz
        v: height  900 start  901 end  904 total 1000           clock  60.00Hz
  1280x1024 (0x6a) 108.000MHz +HSync +VSync
        h: width  1280 start 1328 end 1440 total 1688 skew    0 clock  63.98KHz
        v: height 1024 start 1025 end 1028 total 1066           clock  60.02Hz
  1440x900 (0x1bb) 106.500MHz -HSync +VSync
        h: width  1440 start 1520 end 1672 total 1904 skew    0 clock  55.93KHz
        v: height  900 start  903 end  909 total  934           clock  59.89Hz
  1280x720 (0x1bc) 74.250MHz +HSync +VSync
        h: width  1280 start 1390 end 1430 total 1650 skew    0 clock  45.00KHz
        v: height  720 start  725 end  730 total  750           clock  60.00Hz
  1280x720 (0x1bd) 74.250MHz +HSync +VSync
        h: width  1280 start 1720 end 1760 total 1980 skew    0 clock  37.50KHz
        v: height  720 start  725 end  730 total  750           clock  50.00Hz
  1280x720 (0x1be) 74.176MHz +HSync +VSync
        h: width  1280 start 1390 end 1430 total 1650 skew    0 clock  44.96KHz
        v: height  720 start  725 end  730 total  750           clock  59.94Hz
  1024x768 (0x7b) 65.000MHz -HSync -VSync
        h: width  1024 start 1048 end 1184 total 1344 skew    0 clock  48.36KHz
        v: height  768 start  771 end  777 total  806           clock  60.00Hz
  800x600 (0x8a) 40.000MHz +HSync +VSync
        h: width   800 start  840 end  968 total 1056 skew    0 clock  37.88KHz
        v: height  600 start  601 end  605 total  628           clock  60.32Hz
  720x480 (0x1bf) 27.027MHz -HSync -VSync
        h: width   720 start  736 end  798 total  858 skew    0 clock  31.50KHz
        v: height  480 start  489 end  495 total  525           clock  60.00Hz
  720x480 (0x1c0) 27.000MHz -HSync -VSync
        h: width   720 start  736 end  798 total  858 skew    0 clock  31.47KHz
        v: height  480 start  489 end  495 total  525           clock  59.94Hz
  640x480 (0x1c1) 25.200MHz -HSync -VSync
        h: width   640 start  656 end  752 total  800 skew    0 clock  31.50KHz
        v: height  480 start  490 end  492 total  525           clock  60.00Hz
  640x480 (0x97) 25.175MHz -HSync -VSync
        h: width   640 start  656 end  752 total  800 skew    0 clock  31.47KHz
        v: height  480 start  490 end  492 total  525           clock  59.94Hz
  720x400 (0x1c2) 28.320MHz -HSync +VSync
        h: width   720 start  738 end  846 total  900 skew    0 clock  31.47KHz
        v: height  400 start  412 end  414 total  449           clock  70.08Hz
DP-1-1 disconnected (normal left inverted right x axis y axis)
	Identifier: 0x1b5
	Timestamp:  160592520
	Subpixel:   unknown
	Clones:    
	CRTCs:      0 1 2
	Transform:  1.000000 0.000000 0.000000
	            0.000000 1.000000 0.000000
	            0.000000 0.000000 1.000000
	           filter: 
	non-desktop: 0 
		supported: 0, 1
```