### PR TITLE
Handle non-ASCII environment variable values

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -1107,7 +1107,11 @@ def dispatch_call_to_sessions(argv):
             continue
 
         process_environ = {}
-        for environ_entry in open(environ_file).read().split("\0"):
+        for environ_entry in open(environ_file, 'rb').read().split(b"\0"):
+            try:
+                environ_entry = environ_entry.decode("ascii")
+            except UnicodeDecodeError:
+                continue
             name, sep, value = environ_entry.partition("=")
             if name and sep:
                 if name == "DISPLAY" and "." in value:


### PR DESCRIPTION
When a process has an UTF-8 character in its environment, autorandr
crashes with:

```
Unhandled exception ('utf-8' codec can't decode byte 0xab in position 0: invalid start byte). Please report this as a bug at https://github.com/phillipberndt/autorandr/issues.
Traceback (most recent call last):
  File "./autorandr.py", line 1439, in <module>
    exception_handled_main()
  File "./autorandr.py", line 1423, in exception_handled_main
    main(sys.argv)
  File "./autorandr.py", line 1203, in main
    dispatch_call_to_sessions([x for x in argv if x != "--batch"])
  File "./autorandr.py", line 1110, in dispatch_call_to_sessions
    for environ_entry in open(environ_file).read().split("\0"):
  File "/usr/lib/python3.7/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xab in position 0: invalid start byte
```

Instead, we read the environment without decoding and convert to ASCII
explicitely. Any environment variable not decodable will just be
skipped.