### PR TITLE
Fork and exec using the current Python interpreter

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -1084,7 +1084,7 @@ def dispatch_call_to_sessions(argv):
             os.chdir(pwent.pw_dir)
             os.environ.clear()
             os.environ.update(process_environ)
-            os.execl(autorandr_binary, autorandr_binary, *argv[1:])
+            os.execl(sys.executable, sys.executable, autorandr_binary, *argv[1:])
             os.exit(1)
         os.waitpid(child_pid, 0)
 


### PR DESCRIPTION
When testing against various versions of Python by invoking autorandr
with an explicit Python interpreter, in batch mode, autorandr will
reexecute itself without specifying the Python interpreter. This
change makes sure it is reexecuted using the current Python
interpreter.