### PR TITLE
contrib: zsh completion

### DIFF
--- a/contrib/zsh_completion/_autorandr
+++ b/contrib/zsh_completion/_autorandr
@@ -1,0 +1,40 @@
+#compdef autorandr
+
+__autorandr_profile () {
+    declare -a virtual
+    virtual=("off":"disable all outputs"
+             "common":"clone at the largest common resolution"
+             "clone-largest":"clone with the largest resolution"
+             "horizontal":"stack all connected outputs horizontally"
+             "vertical":"stack all connected outputs vertically")
+    _describe -t virtual-profiles "virtual profiles" virtual
+    __autorandr_saved_profile
+}
+__autorandr_saved_profile () {
+    declare -a saved
+    saved=(${${(f)${:-$(autorandr)}}/ /:})
+    _describe -t profiles "saved profiles" saved
+}
+
+_autorandr () {
+    local curcontext="$curcontext" state line exclude="-s --save -l --load -r --remove -c --change"
+
+    _arguments -C \
+       "(: -)"{-h,--help}"[get help]" \
+       "($exclude)"{-c,--change}"[automatically load the first detected profile]" \
+       "($exclude)"{-d,--default}"[set default profile]:profile:__autorandr_profile" \
+       "($exclude)"{-l,--load}"[load profile]:profile:__autorandr_profile" \
+       "($exclude)"{-s,--save}"[save current setup to a profile]:profile: " \
+       "($exclude)"{-r,--remove}"[remove profile]:profile:__autorandr_saved_profile" \
+       --batch"[run autorandr for all users]" \
+       --current"[list current active configurations]" \
+       --config"[dump current xrandr setup]" \
+       --debug"[enable verbose output]" \
+       --dry-run"[don't change anything]" \
+       --fingerprint"[fingerprint current hardware]" \
+       --force"[force loading of a profile]" \
+       --skip-options"[skip xrandr options]:xrandr options:_values -s , options gamma brightness panning transform primary mode pos rate" \
+       --version"[show version]"
+}
+
+_autorandr "$@"


### PR DESCRIPTION
```console
$ autorandr --
option
--batch         -- run autorandr for all users
--change        -- automatically load the first detected profile
--config        -- dump current xrandr setup
--current       -- list current active configurations
--debug         -- enable verbose output
--default       -- set default profile
--dry-run       -- don't change anything
--fingerprint   -- fingerprint current hardware
--force         -- force loading of a profile
--help          -- get help
--load          -- load profile
--remove        -- remove profile
--save          -- save current setup to a profile
--skip-options  -- skip xrandr options
--version       -- show version
```

```console
$ autorandr --load
virtual profiles
clone-largest  -- clone with the largest resolution
common         -- clone at the largest common resolution
horizontal     -- stack all connected outputs horizontally
off            -- disable all outputs
vertical       -- stack all connected outputs vertically
saved profiles
default  -- (detected) (current)
blade
```