### PR TITLE
Save and restore output properties "Broadcast RGB" and "audio"

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -71,6 +71,11 @@ properties = [
     "Broadcast RGB",
     "audio",
     "non-desktop",
+    "TearFree",
+    "underscan vborder",
+    "underscan hborder",
+    "underscan",
+    "scaling mode",
 ]
 
 help_text = """
@@ -161,7 +166,7 @@ class XrandrOutput(object):
 
     XRANDR_PROPERTIES_REGEXP = "|".join(
         [r"{}:\s*(?P<{}>[\S ]*\S+)"
-         .format(p, re.sub(r"\W+", "_", p.lower()))
+         .format(re.sub(r"\s", r"\\\g<0>", p), re.sub(r"\W+", "_", p.lower()))
             for p in properties])
 
     # This regular expression is used to parse an output in `xrandr --verbose'

--- a/autorandr.py
+++ b/autorandr.py
@@ -64,6 +64,15 @@ virtual_profiles = [
     ("vertical", "Stack all connected outputs vertically at their largest resolution", None),
 ]
 
+properties = [
+    "Colorspace",
+    "max bpc",
+    "aspect ratio",
+    "Broadcast RGB",
+    "audio",
+    "non-desktop",
+]
+
 help_text = """
 Usage: autorandr [options]
 
@@ -176,6 +185,7 @@ class XrandrOutput(object):
             CRTC:\s*(?P<crtc>[0-9]) |                                                   # CRTC value
             Transform: (?P<transform>(?:[\-0-9\. ]+\s+){3}) |                           # Transformation matrix
             EDID: (?P<edid>\s*?(?:\\n\\t\\t[0-9a-f]+)+) |                               # EDID of the output
+            %s |                                                                        # Properties to include in the profile
             (?![0-9])[^:\s][^:\n]+:.*(?:\s\\t[\\t ].+)*                                 # Other properties
         ))+
         \s*
@@ -185,7 +195,9 @@ class XrandrOutput(object):
              v:\s+height\s+(?P<mode_height>[0-9]+).+clock\s+(?P<rate>[0-9\.]+)Hz\s* |
             \S+(?:(?!\*current).)+\s+h:.+\s+v:.+\s*                                     # Other resolutions
         )*)
-    """
+    """ % ("|".join([r"{}:\s*(?P<{}>[\S ]*\S+)"
+                     .format(re.sub(r"(\s)", r"\\\1", p),
+                             re.sub(r"\W+", "_", p.lower())) for p in properties]))
 
     XRANDR_OUTPUT_MODES_REGEXP = """(?x)
         (?P<name>\S+).+?(?P<preferred>\+preferred)?\s+
@@ -238,7 +250,19 @@ class XrandrOutput(object):
         "Return the command line parameters for XRandR for this instance"
         args = ["--output", self.output]
         for option, arg in sorted(self.options_with_defaults.items()):
-            args.append("--%s" % option)
+            if option[:5] == "prop-":
+                prop_found = False
+                for prop, xrandr_prop in [(re.sub(r"\W+", "_", p.lower()), p) for p in properties]:
+                    if prop == option[5:]:
+                        args.append("--set")
+                        args.append(xrandr_prop)
+                        prop_found = True
+                        break
+                if not prop_found:
+                    print("Warning: Unknown property `%s' in config file. Skipping." % option[5:], file=sys.stderr)
+                    continue
+            else:
+                args.append("--%s" % option)
             if arg:
                 args.append(arg)
         return args
@@ -387,6 +411,9 @@ class XrandrOutput(object):
                 options["crtc"] = match["crtc"]
             if match["rate"]:
                 options["rate"] = match["rate"]
+            for prop in [re.sub(r"\W+", "_", p.lower()) for p in properties]:
+                if match[prop]:
+                    options["prop-" + prop] = match[prop]
 
         return XrandrOutput(match["output"], edid, options), modes
 
@@ -608,7 +635,8 @@ def find_profiles(current_config, profiles):
         if not matches or any((name not in config.keys() for name in current_config.keys() if current_config[name].edid)):
             continue
         if matches:
-            closeness = max(match_asterisk(output.edid, current_config[name].edid), match_asterisk(current_config[name].edid, output.edid))
+            closeness = max(match_asterisk(output.edid, current_config[name].edid), match_asterisk(
+                current_config[name].edid, output.edid))
             detected_profiles.append((closeness, profile_name))
     detected_profiles = [o[1] for o in sorted(detected_profiles, key=lambda x: -x[0])]
     return detected_profiles
@@ -1205,6 +1233,7 @@ def read_config(options, directory):
     if config.has_section("config"):
         for key, value in config.items("config"):
             options.setdefault("--%s" % key, value)
+
 
 def main(argv):
     try:


### PR DESCRIPTION
`Broadcast RGB` defaults to `Automatic`, which in my experience can mean `Limited 16:235` even when hardware is capable of `Full`, leading to washed out or excessively bright output. autorandr's lack of support for output properties managed via `xrandr --set` forced me to find a much less elegant solution, but now I'm proposing this fix instead.

(Persisting the `audio` property is far less important, but disabling display audio automatically will make my life simpler, so I've included that as well.)

These options represent multiple possible `--set` arguments, each with a property name and value, either of which may contain spaces. Lines in `~/.config/autorandr/*/config` only map one xrandr argument to one value, so the new values are being stored as `broadcast-rgb` and `audio` respectively. To avoid a massive re-work of code that touches `*.options` in `autorandr.py`, these "options" aren't converted to `--set <property> <value>` until the last possible moment, i.e. in `option_vector`.

This means `--skip-options` values will need to correspond to stored names (`broadcast-rgb`) rather than the final argument name (i.e. `set`, which would be ambiguous anyway).