### PR TITLE
Handle empty sys.executable

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -1107,7 +1107,10 @@ def dispatch_call_to_sessions(argv):
             os.chdir(pwent.pw_dir)
             os.environ.clear()
             os.environ.update(process_environ)
-            os.execl(sys.executable, sys.executable, autorandr_binary, *argv[1:])
+            if sys.executable != "":
+                os.execl(sys.executable, sys.executable, autorandr_binary, *argv[1:])
+            else:
+                os.execl(autorandr_binary, autorandr_binary, *argv[1:])
             os.exit(1)
         os.waitpid(child_pid, 0)
 

--- a/autorandr.py
+++ b/autorandr.py
@@ -1107,7 +1107,7 @@ def dispatch_call_to_sessions(argv):
             os.chdir(pwent.pw_dir)
             os.environ.clear()
             os.environ.update(process_environ)
-            if sys.executable != "":
+            if sys.executable != "" and sys.executable != None:
                 os.execl(sys.executable, sys.executable, autorandr_binary, *argv[1:])
             else:
                 os.execl(autorandr_binary, autorandr_binary, *argv[1:])


### PR DESCRIPTION
This is related to [this](https://stackoverflow.com/questions/62528346/unset-path-variable-and-execute-python-program-with-shebang) stackoverflow question I asked.
When `udev` executes this script, there is no `PATH` environmental variable set, so `sys.executable` resolves to an empty string, and the script crashes.
In case `sys.executable` is empty, fall back to calling `autorandr_binary` directly