### PR TITLE
Fix UnicodeDecodeError edge case in python 3

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -1138,7 +1138,7 @@ def dispatch_call_to_sessions(argv):
                 environ_entry = environ_entry.decode("ascii")
             except UnicodeDecodeError:
                 continue
-            name, sep, value = environ_entry.partition("=")
+            name, sep, value = environ_entry.partition(b"=")
             if name and sep:
                 if name == "DISPLAY" and "." in value:
                     value = value[:value.find(".")]


### PR DESCRIPTION
If decode throws UnicodeDecodeError, environ_entry will be a bytes
object, which breaks in python3 if a string argument is supplied to
partition. This method requires "a bytes-like object" not a string.