### PR TITLE
In batch mode, set groups to group membership of target user.

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -1101,7 +1101,11 @@ def dispatch_call_to_sessions(argv):
             # so it should be safe. Also, note that since the environment
             # is taken from a process owned by the user, reusing it should
             # not leak any information.
-            os.setgroups(os.getgrouplist(pwent.pw_name, pwent.pw_gid))
+            try:
+                os.setgroups(os.getgrouplist(pwent.pw_name, pwent.pw_gid))
+            except AttributeError:
+                # Python 2 doesn't have getgrouplist
+                os.setgroups([])
             os.setresgid(pwent.pw_gid, pwent.pw_gid, pwent.pw_gid)
             os.setresuid(pwent.pw_uid, pwent.pw_uid, pwent.pw_uid)
             os.chdir(pwent.pw_dir)

--- a/autorandr.py
+++ b/autorandr.py
@@ -1101,7 +1101,7 @@ def dispatch_call_to_sessions(argv):
             # so it should be safe. Also, note that since the environment
             # is taken from a process owned by the user, reusing it should
             # not leak any information.
-            os.setgroups([])
+            os.setgroups(os.getgrouplist(pwent.pw_name, pwent.pw_gid))
             os.setresgid(pwent.pw_gid, pwent.pw_gid, pwent.pw_gid)
             os.setresuid(pwent.pw_uid, pwent.pw_uid, pwent.pw_uid)
             os.chdir(pwent.pw_dir)


### PR DESCRIPTION
Previously, group list was cleared during privilege de-escalation. This causes
profiles scripts to be run as the local user with an empty group list. This can
cause issues when, eg, the 'video' group is required for backlight control,
and the user is trying to invoke xbacklight from postswitch.sh.