### PR TITLE
Reword README regarding environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,17 +194,30 @@ it has a unique name.
 If you switch back from `docked` to `mobile`, `~/.config/autorandr/postswitch`
 is executed instead of the `docked` specific `postswitch`.
 
-In these scripts, some of autorandr's state is exposed as environment variables
+If you experience issues with xrandr being executed too early after connecting
+a new monitor, then you can use a `predetect` script to delay the execution.
+Write e.g. `sleep 1` into that file to make autorandr wait a second before
+running `xrandr`.
+
+#### Variables
+
+Some of autorandr's state is exposed as environment variables
 prefixed with `AUTORANDR_`, such as:
 - `AUTORANDR_CURRENT_PROFILE`
 - `AUTORANDR_CURRENT_PROFILES`
 - `AUTORANDR_PROFILE_FOLDER`
 - `AUTORANDR_MONITORS`
 
-If you experience issues with xrandr being executed too early after connecting
-a new monitor, then you can use a `predetect` script to delay the execution.
-Write e.g. `sleep 1` into that file to make autorandr wait a second before
-running `xrandr`.
+with the intention that they can be used within the hook scripts.
+
+For instance, you might display which profile has just been activated by
+including the following in a `postswitch` script:
+```sh
+notify-send -i display "Display profile" "$AUTORANDR_CURRENT_PROFILE"
+```
+
+The one kink is that during `preswitch`, `AUTORANDR_CURRENT_PROFILE` is
+reporting the *upcoming* profile rather than the *current* one.
 
 ### Wildcard EDID matching
 

--- a/contrib/packaging/rpm/autorandr.spec
+++ b/contrib/packaging/rpm/autorandr.spec
@@ -239,17 +239,30 @@ it has a unique name.
 If you switch back from `docked` to `mobile`, `~/.config/autorandr/postswitch`
 is executed instead of the `docked` specific `postswitch`.
 
-In these scripts, some of autorandr's state is exposed as environment variables
+If you experience issues with xrandr being executed too early after connecting
+a new monitor, then you can use a `predetect` script to delay the execution.
+Write e.g. `sleep 1` into that file to make autorandr wait a second before
+running `xrandr`.
+
+#### Variables
+
+Some of autorandr's state is exposed as environment variables
 prefixed with `AUTORANDR_`, such as:
 - `AUTORANDR_CURRENT_PROFILE`
 - `AUTORANDR_CURRENT_PROFILES`
 - `AUTORANDR_PROFILE_FOLDER`
 - `AUTORANDR_MONITORS`
 
-If you experience issues with xrandr being executed too early after connecting
-a new monitor, then you can use a `predetect` script to delay the execution.
-Write e.g. `sleep 1` into that file to make autorandr wait a second before
-running `xrandr`.
+with the intention that they can be used within the hook scripts.
+
+For instance, you might display which profile has just been activated by
+including the following in a `postswitch` script:
+```sh
+notify-send -i display "Display profile" "$AUTORANDR_CURRENT_PROFILE"
+```
+
+The one kink is that during `preswitch`, `AUTORANDR_CURRENT_PROFILE` is
+reporting the *upcoming* profile rather than the *current* one.
 
 ### Wildcard EDID matching
 


### PR DESCRIPTION
This clarifies the usage somewhat, without needing changes to existing
functionality. I may look into reworking the variables, but until then
this will be an improvement. That is to say, this is meant to NOT
resolve issue #230.

- Add section heading for variables
- Move `predetect`/`sleep` example up above new section
- Add example usage of variable, and explain the oddity with 'current'
profile during preswitch.