### PR TITLE
Elaborate on settings.ini usage and format

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,20 @@ names in your configuration directory to have autorandr use any of them
 as the default configuration without you having to change the system-wide
 configuration.
 
-You can store default values for any option in an INI-file in
-`~/.config/autorandr/settings.ini` in a section `config`. The most useful
-candidate for doing that is `skip-options`, if you need it.
+You can store default values for any option in an INI-file located at
+`~/.config/autorandr/settings.ini`. In a `config` section, you may place any
+default values in the form `option-name=option-argument`.
+
+A common and effective use of this is to specify default `skip-options`, for
+instance skipping the `gamma` setting if using
+[`redshift`](https://github.com/jonls/redshift) as a daemon.  To implement
+the equivalent of `--skip-options gamma`, your `settings.ini` file should look
+like this:
+
+```
+[config]
+skip-options=gamma
+```
 
 ## Advanced usage
 


### PR DESCRIPTION
I use `autorandr` on a system that has a `redshift` daemon running to adjust the color temperature.  I had found that every time I used `autorandr`, it would set the current gamma, then `redshift` would adjust based on that, magnifying the effect.

It took me quite some time to identify that the `gamma` option was at play, and then I had to look at the `autorandr` source to figure out the expected format of the `settings.ini` file.

This PR addresses both of those by clarifying the INI format (with an example) and illustrating an example scenario that mentions `redshift` so that users down the line will land somewhere if they Ctrl-f -> "redshift" on the README, which might prevent future "bug" reports :)

Thanks for all of your work!