### PR TITLE
Replace deprecated distutils with packaging.

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -39,9 +39,13 @@ import time
 import glob
 
 from collections import OrderedDict
-from distutils.version import LooseVersion as Version
 from functools import reduce
 from itertools import chain
+
+try:
+    from packaging.version import Version
+except ModuleNotFound:
+    from distutils.version import LooseVersion as Version
 
 if sys.version_info.major == 2:
     import ConfigParser as configparser


### PR DESCRIPTION
This is a fix for #266, a DeprecationWarning about distutils package.