### PR TITLE
Get all events from dbus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,17 @@ uninstall_launcher:
 	rm -f ${DESTDIR}${PREFIX}/bin/autorandr-launcher
 	rm -f ${DESTDIR}/${XDG_AUTOSTART_DIR}/autorandr-launcher.desktop
 
+# Rules for dbus_monitor
+DEFAULT_TARGETS+=dbus_monitor
+
+install_dbus_monitor:
+	install -D -m 755 contrib/autorandr_dbus_monitor.sh ${DESTDIR}${PREFIX}/bin/autorandr_dbus_monitor
+	install -D -m 644 contrib/etc/xdg/autostart/autorandr_dbus_monitor.desktop ${DESTDIR}/${XDG_AUTOSTART_DIR}/autorandr_dbus_monitor.desktop
+
+uninstall_dbus_monitor:
+	rm -f ${DESTDIR}${PREFIX}/bin/autorandr_dbus_monitor
+	rm -f ${DESTDIR}/${XDG_AUTOSTART_DIR}/autorandr_dbus_monitor.desktop
+
 TARGETS=$(DEFAULT_TARGETS)
 install: $(patsubst %,install_%,$(TARGETS))
 uninstall: $(patsubst %,uninstall_%,$(TARGETS))

--- a/contrib/autorandr_dbus_monitor.sh
+++ b/contrib/autorandr_dbus_monitor.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2021 Christophe-Marie Duquesne
+
+pipe=$(mktemp -u /tmp/autorandr.XXXXXXXX)
+
+trap "rm -f $pipe" EXIT
+
+if [[ ! -p $pipe ]]; then
+    mkfifo $pipe
+fi
+
+suspend_event="type='signal',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'"
+lid_event="type='signal',path=/org/freedesktop/UPower,member=PropertiesChanged"
+display_event="type='signal',path=/org/freedesktop/ColorManager"
+
+stdbuf -oL dbus-monitor --system --profile $lid_event | grep "LidIsClosed" > $pipe &
+stdbuf -oL dbus-monitor --system --profile $display_event > $pipe &
+stdbuf -oL dbus-monitor --system --profile $suspend_event > $pipe &
+
+while true; do
+    if read line <$pipe; then
+        autorandr --change --default default
+    fi
+done
+
+echo "Exiting"

--- a/contrib/etc/xdg/autostart/autorandr_dbus_monitor.desktop
+++ b/contrib/etc/xdg/autostart/autorandr_dbus_monitor.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Autorandr Dbus Monitor
+Comment=Trigger autorandr whenever the screen configuration changes
+Type=Application
+Exec=/usr/bin/autorandr_dbus_monitor
+X-GNOME-Autostart-Phase=Initialization


### PR DESCRIPTION
Hi there,

`autorandr_dbus_monitor` is a script to automatically trigger autorandr based on events collected via `dbus-monitor`. If you have `dbus` (which is a dependency of `systemd`), then you have `dbus-monitor`.

This script will trigger autorandr:
* every time an external display is plugged/unplugged
* every time the lid is open/closed
* every time the system suspends/wakes up

I believe this could replace a lot of code.

Cheers,
Christophe-Marie