### PR TITLE
Allow overriding min UID with AUTORANDR_UID_MIN env var.

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -1198,6 +1198,16 @@ def dispatch_call_to_sessions(argv):
             sys.exit(1)
         os.waitpid(child_pid, 0)
 
+    # The following line assumes that user accounts start at 1000 and that no
+    # one works using the root or another system account. This is rather
+    # restrictive, but de facto default. If this breaks your use case, set the
+    # env var AUTORANDR_UID_MIN as appropriate. (Alternatives would be to use
+    # the UID_MIN from /etc/login.defs or FIRST_UID from /etc/adduser.conf; but
+    # effectively, both values aren't binding in any way.)
+    uid_min = 1000
+    if 'AUTORANDR_UID_MIN' in os.environ:
+      uid_min = int(os.environ['AUTORANDR_UID_MIN'])
+
     for directory in os.listdir("/proc"):
         directory = os.path.join("/proc/", directory)
         if not os.path.isdir(directory):
@@ -1207,13 +1217,7 @@ def dispatch_call_to_sessions(argv):
             continue
         uid = os.stat(environ_file).st_uid
 
-        # The following line assumes that user accounts start at 1000 and that
-        # no one works using the root or another system account. This is rather
-        # restrictive, but de facto default. Alternatives would be to use the
-        # UID_MIN from /etc/login.defs or FIRST_UID from /etc/adduser.conf;
-        # but effectively, both values aren't binding in any way.
-        # If this breaks your use case, please file a bug on Github.
-        if uid < 1000:
+        if uid < uid_min:
             continue
 
         process_environ = {}


### PR DESCRIPTION
Fixes #262.

My UID is 501 and I've tested this locally with `sudo DISPLAY= AUTORANDR_UID_MIN=501 /usr/bin/autorandr --batch --change --default default --debug`. It correctly runs the scripts for my UID.

I then made this system-wide with `sudo systemctl edit autorandr` (which [in turn created](https://serverfault.com/a/413408) `/etc/systemd/system/autorandr.service.d/override.conf`) with the following content:

```
[Service]
Environment="AUTORANDR_UID_MIN=501"
```

All of this worked like a charm.

Note: I've went with `AUTORANDR_UID_MIN` (instead of "min uid") for consistency with `UID_MIN` from /etc/login.defs`. The `AUTORANDR_` prefix is mainly for avoiding potential conflicts with anything else. Please feel free to edit the PR as needed.