### PR TITLE
Fix 'make deb' build target to build a .deb package

### DIFF
--- a/contrib/packaging/debian/debian/control
+++ b/contrib/packaging/debian/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>=9)
 Standards-Version: 3.9.6
 Homepage: https://github.com/phillipberndt/autorandr
 Architecture: all
-Depends: x11-xserver-utils, python
+Depends: x11-xserver-utils, python3
 Description: Automatically select a display configuration for connected devices
  Autorandr is a script for managing xrandr configurations based on the
  connected devices. It can be set up to automatically switch to a stored

--- a/contrib/packaging/debian/make_deb.sh
+++ b/contrib/packaging/debian/make_deb.sh
@@ -45,7 +45,7 @@ SIZE=$(du -s $D | awk '{print $1}')
 
 cp -r "$P/debian" "$D/DEBIAN"
 chmod 0755 "$D/DEBIAN"
-[ -d "$D/etc" ] && (cd $D; find etc -type f) > "$D/DEBIAN/conffiles"
+[ -d "$D/etc" ] && (cd $D; find etc -type f -printf '/%p\n') > "$D/DEBIAN/conffiles"
 sed -i -re "s#Version:.+#Version: $V#" "$D/DEBIAN/control"
 echo "Installed-Size: $SIZE" >> "$D/DEBIAN/control"
 fakeroot dpkg-deb -b "$D" "$O"


### PR DESCRIPTION
- Add a leading slash to Debian conffiles paths
- Make the Debian package depend on python3 rather than python