### PR TITLE
Extended --match-edid to respect a device's serial

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Contributors to this version of autorandr are:
 
 * Adrián López
 * andersonjacob
+* Alexander Lochmann
 * Alexander Wirt
 * Brice Waegeneire
 * Chris Dunder


### PR DESCRIPTION
Autorandr parses a device's EDID to extract its
serial number. If --match-edid is used and the serial
is available, a profile is first matched based
on the serial number. If not available,
the old EDID-based behavior is used.
This way a profile can be matched precisly, even if
the EDID data changes. This might be the case
if a monitor's connection is switched from HDMI to
VGA, for example.