### PR TITLE
execute scripts in directories in a fixed order (by file name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ where they will only be executed on changes regarding that specific profile.
 
 Instead (or in addition) to these scripts, you can also place as many executable
 files as you like in subdirectories called `script_name.d` (e.g. `postswitch.d`).
+The order of execution of scripts in these directories is by file name, you can
+force a certain ordering by naming them `10-wallpaper`, `20-restart-wm`, etc.
 
 If a script with the same name occurs multiple times, user configuration
 takes precedence over system configuration (as specified by the

--- a/autorandr.py
+++ b/autorandr.py
@@ -1180,7 +1180,7 @@ def exec_scripts(profile_path, script_name, meta_information=None):
 
         script_folder = os.path.join(folder, "%s.d" % script_name)
         if os.access(script_folder, os.R_OK | os.X_OK) and os.path.isdir(script_folder):
-            for file_name in os.listdir(script_folder):
+            for file_name in sorted(os.listdir(script_folder)):
                 check_name = "d/%s" % (file_name,)
                 if check_name not in ran_scripts:
                     script = os.path.join(script_folder, file_name)


### PR DESCRIPTION
Scripts might have dependencies among each other. In my case, I set `Xft.dpi` in one script, then other scripts use this information to make scaling decisions accordingly.