### PR TITLE
Force autorandr on autostart

### DIFF
--- a/contrib/etc/xdg/autostart/autorandr.desktop
+++ b/contrib/etc/xdg/autostart/autorandr.desktop
@@ -2,5 +2,5 @@
 Name=Autorandr
 Comment=Automatically select a display configuration based on connected devices
 Type=Application
-Exec=/usr/bin/autorandr -c --default default
+Exec=/usr/bin/autorandr -c --default default --force
 X-GNOME-Autostart-Phase=Initialization


### PR DESCRIPTION
In some situations autorandr detects the screen setup as "already applied" and skip processing. But it is for the xrandr settings only. I use autorandr mainly to change pulseaudio output settings. Forcing autorandr in autostart forces to set pulseaudio and maybe other things, so non-xrandr parts are properly set up.