### PR TITLE
RPM spec: Add conditional Recommends

### DIFF
--- a/contrib/packaging/rpm/autorandr.spec
+++ b/contrib/packaging/rpm/autorandr.spec
@@ -15,6 +15,8 @@ BuildRequires: systemd
 BuildRequires: udev
 BuildRequires: desktop-file-utils
 
+Recommends:    (%{name}-bash-completion = %{version}-%{release} if bash)
+Recommends:    (%{name}-zsh-completion = %{version}-%{release} if zsh)
 
 %description
 %{summary}.


### PR DESCRIPTION
Makes sense to have the main package Recommend whatever completion subpackages match the currently-available shells.