### PR TITLE
Add ge method to custom Version type

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -135,6 +135,8 @@ class Version(object):
                 return True
         return len(theirs) > len(my)
 
+    def __ge__(self, other):
+        return not (self < other)
 
 def is_closed_lid(output):
     if not re.match(r'(eDP(-?[0-9]\+)*|LVDS(-?[0-9]\+)*)', output):


### PR DESCRIPTION
Fixes crash with xrandr version comparison.