### PR TITLE
Add completions for fish shell

### DIFF
--- a/contrib/fish_copletion/autorandr.fish
+++ b/contrib/fish_copletion/autorandr.fish
@@ -1,0 +1,28 @@
+# don't complete directories and paths
+complete -c autorandr -f
+
+set -l virtual_profiles off common clone-largest horizontal vertical
+set -l user_profiles (autorandr --list)
+set -l profile_users -d --default -s --save -l --load -r --remove
+
+complete -c autorandr -n "__fish_seen_subcommand_from $profile_users" \
+    -a "$virtual_profiles $user_profiles"
+
+complete -c autorandr -s -h -l help -d 'get help'
+complete -c autorandr -s -c -l change -d 'automatically load the first detected profile'
+complete -c autorandr -s -d -l default -d 'set default PROFILE'
+complete -c autorandr -s -l -l load -d 'load PROFILE'
+complete -c autorandr -s -s -l save -d 'save current setup to a PROFILE'
+complete -c autorandr -s -r -l remove -d 'remove PROFILE'
+complete -c autorandr -l current -d 'list curren active configurations'
+complete -c autorandr -l cycle -d 'cycle through all detected drofiles'
+complete -c autorandr -l config -d 'dump current xrandr setup'
+complete -c autorandr -l debug -d 'enable verbose output'
+complete -c autorandr -l dry-run -d 'don\'t change anything'
+complete -c autorandr -l fingerprint -d 'fingerprint current hardware'
+complete -c autorandr -l match-edid -d 'match displays using edid'
+complete -c autorandr -l force -d 'force loading of a profile'
+complete -c autorandr -l list -d 'list all profiles'
+complete -c autorandr -l skip-options -d 'Set a comma-separated lis of xrandr arguments to skip buth in change detection and profile application'
+complete -c autorandr -l ignore-lid -d 'By default, closed lids are considered as disconnected if other outputs are detected. This flag disables this behavior'
+complete -c autorandr -l version -d 'show version'

--- a/contrib/packaging/rpm/autorandr.spec
+++ b/contrib/packaging/rpm/autorandr.spec
@@ -16,6 +16,7 @@ BuildRequires: udev
 BuildRequires: desktop-file-utils
 
 Recommends:    (%{name}-bash-completion = %{version}-%{release} if bash)
+Recommends:    (%{name}-fish-completion = %{version}-%{release} if fish)
 Recommends:    (%{name}-zsh-completion = %{version}-%{release} if zsh)
 
 %description
@@ -42,6 +43,12 @@ Requires: bash-completion
 %description bash-completion
 This package provides bash-completion files for autorandr
 
+%package fish-completion
+Summary: Fish completion for autorandr
+Requires: %{name}
+Requires: fish-completion
+%description fish-completion
+This package provides fish-completion files for autorandr
 
 %package zsh-completion
 Summary: Zsh completion for autorandr
@@ -54,6 +61,7 @@ This package provides zsh-completion files for autorandr
 %make_install
 install -vDm 644 README.md -t "%{buildroot}/usr/share/doc/%{name}/"
 install -vDm 644 contrib/bash_completion/autorandr -t %{buildroot}%{_datadir}/bash-completion/completions/
+install -vDm 644 contrib/fish_completion/autorandr.fish -t %{buildroot}%{_datadir}/fish/vendor_completions.d/
 install -vDm 644 contrib/zsh_completion/_autorandr -t %{buildroot}%{_datadir}/zsh/site-functions/
 install -vDm 644 autorandr.1 -t %{buildroot}%{_mandir}/man1/
 
@@ -71,6 +79,9 @@ desktop-file-validate %{buildroot}%{_sysconfdir}/xdg/autostart/autorandr.desktop
 
 %files bash-completion
 %{_datadir}/bash-completion/completions/autorandr
+
+%files fish-completion
+%{_datadir}/fish/vendor_completions.d/autorandr.fish
 
 %files zsh-completion
 %{_datadir}/zsh/site-functions/_autorandr


### PR DESCRIPTION
This add completions for the fish shell.
The default install destination would be `/usr/share/fish/vendor_completions.d/autorandr.fish`.

One potential improvement might be to highlight the destinction between user and virtual profiles, but I am not sure if this is needed and how to do it without adding some complex function.

I added it also to the `rpm` script by adopting from the zsh completions, but as I am not actually familiar with packaging rpm I am not sure if this is correct. Updating the ArchLinux and AUR packages would be great.