### PR TITLE
Fixes incorrect udev rule creation on a system that uses systemd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ endif
 install_udev:
 	$(if $(UDEV_RULES_DIR),,$(error UDEV_RULES_DIR is not defined))
 	mkdir -p ${DESTDIR}/${UDEV_RULES_DIR}/
-	echo 'ACTION=="change", SUBSYSTEM=="drm", RUN+="$(if $(findstring systemd, $(MAKECMDGOALS)),/bin/systemctl start --no-block autorandr.service,${PREFIX}/bin/autorandr --batch --change --default default)"' > ${DESTDIR}/${UDEV_RULES_DIR}/40-monitor-hotplug.rules
+	echo 'ACTION=="change", SUBSYSTEM=="drm", RUN+="$(if $(findstring systemd, $(DEFAULT_TARGETS)),/bin/systemctl start --no-block autorandr.service,${PREFIX}/bin/autorandr --batch --change --default default)"' > ${DESTDIR}/${UDEV_RULES_DIR}/40-monitor-hotplug.rules
 	@echo
 	@echo "To activate the udev rules, run this command as root:"
 	@echo "    udevadm control --reload-rules"


### PR DESCRIPTION
Replaced MAKECMDGOALS with DEFAULT_TARGETS in the Makefile, to check if systemd is present and change the udev rule accordingly.

MAKECMDGOALS does not contain the string `"systemd"` although systemd is used on the system. Thus, an incorrect udev rule is created. DEFAULT_TARGETS however does contain `"systemd"`, because of a check earlier in the Makefile: https://github.com/phillipberndt/autorandr/blob/5981c84bcaa213fa678cbaa2dc25e4c244f87107/Makefile#L82-L85

Before this commit, a udev rule is created that launches `autorandr` directly. However, this causes child processes that are created using for example `postswitch` to be killed. With the commit, the udev rule correctly calls the the systemd unit which does not kill the newly created processes. An example where this is helpful, is when creating or destroying status/tray bars, depending on which displays are connected. See also https://github.com/phillipberndt/autorandr/issues/326#issuecomment-1521950804 for more detail.

However, I do not know if this interferes with https://github.com/phillipberndt/autorandr/commit/ef1896d7769ba9c745247d239b3828189276750a, but I suspect not. In that case `DEFAULT_TARGETS` should not contain the string `"systemd"` and thus the udev rule wihtout the systemd unit should be created.