### PR TITLE
Add Wayland awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,19 @@ kernel parameter `nvidia-drm.modeset` must be set to 1. For example, add a file
 options nvidia_drm modeset=1
 ```
 
+### Wayland
+
+Before running autorandr will check the environment for the `WAYLAND_DISPLAY`
+variable to check if the program is running in a Wayland session. This is to
+avoid issues between usage of xrandr in Wayland environments.
+
+If you need to run autorandr in a Wayland environment, one workaround is to
+unset the `WAYLAND_DISPLAY` variable before running the program, such as:
+
+```
+WAYLAND_DISPLAY= autorandr
+```
+
 ## Changelog
 
 **autorandr 1.13.3**

--- a/autorandr.py
+++ b/autorandr.py
@@ -1325,6 +1325,11 @@ def dispatch_call_to_sessions(argv):
             # Cannot work with this environment, skip.
             continue
 
+        if "WAYLAND_DISPLAY" in process_environ and process_environ["WAYLAND_DISPLAY"]:
+            if "--debug" in argv:
+                print("Detected Wayland session '{0}'. Skipping.".format(process_environ["WAYLAND_DISPLAY"]))
+            continue
+
         # To allow scripts to detect batch invocation (especially useful for predetect)
         process_environ["AUTORANDR_BATCH_PID"] = str(os.getpid())
         process_environ["UID"] = str(uid)
@@ -1437,6 +1442,9 @@ def main(argv):
         user = pwd.getpwuid(os.getuid())
         user = user.pw_name if user else "#%d" % os.getuid()
         print("autorandr running as user %s (started from batch instance)" % user)
+    if ("WAYLAND_DISPLAY" in os.environ and os.environ["WAYLAND_DISPLAY"]):
+        print("Detected Wayland session '{0}'. Exiting.".format(os.environ["WAYLAND_DISPLAY"]), file=sys.stderr)
+        sys.exit(1)
 
     profiles = {}
     profile_symlinks = {}


### PR DESCRIPTION
With this commit autorandr will check if the current environment has the `WAYLAND_DISPLAY` environment variable set. If yes, it will exit (in interactive mode) or skip (in batch mode), to avoid issues between xrandr usage and Wayland environments.