### PR TITLE
[autorandr-launcher] Add makefile & create macro to enable local path of autorandr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,8 +160,9 @@ LAUNCHER_LDLIBS=$(shell pkg-config --libs pkg-config xcb xcb-randr 2>/dev/null)
 ifneq (,$(LAUNCHER_LDLIBS))
 CLEANUP_FILES+=contrib/autorandr_launcher/autorandr-launcher
 LAUNCHER_CFLAGS=$(shell pkg-config --cflags pkg-config xcb xcb-randr 2>/dev/null)
+DEF_AUTORANDR_PATH="-DAUTORANDR_PATH=\"${DESTDIR}${PREFIX}/bin/autorandr\""
 contrib/autorandr_launcher/autorandr-launcher: contrib/autorandr_launcher/autorandr_launcher.c
-	$(CC) $(CFLAGS) $(LAUNCHER_CFLAGS) -o $@ $+ $(LDFLAGS) $(LAUNCHER_LDLIBS) $(LDLIBS)
+	$(CC) $(CFLAGS) $(LAUNCHER_CFLAGS) $(DEF_AUTORANDR_PATH) -o $@ $+ $(LDFLAGS) $(LAUNCHER_LDLIBS) $(LDLIBS)
 
 install_launcher: contrib/autorandr_launcher/autorandr-launcher
 	mkdir -p ${DESTDIR}${PREFIX}/bin

--- a/contrib/autorandr_launcher/autorandr_launcher.c
+++ b/contrib/autorandr_launcher/autorandr_launcher.c
@@ -10,6 +10,13 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <time.h>
+#include <inttypes.h>
+#include <errno.h>
+#include <string.h>
+
+#ifndef AUTORANDR_PATH
+#define AUTORANDR_PATH "/usr/bin/autorandr"
+#endif
 
 // indent -kr -i8
 static int VERBOSE = 0;
@@ -21,7 +28,7 @@ static void sigterm_handler(int signum)
 	kill(getpid(), signum);
 }
 
-static void ar_log(const char *format, ...)
+__attribute__((format(printf, 1, 2))) static void ar_log(const char *format, ...)
 {
 	va_list args;
 
@@ -33,13 +40,17 @@ static void ar_log(const char *format, ...)
 	fflush(stdout);
 }
 
-static int ar_launch()
+static int ar_launch(void)
 {
 	pid_t pid = fork();
 	if (pid == 0) {
-		static char *argv[] =
-		    { "/usr/bin/autorandr", "--change", "--default", "default", NULL };
-		execve(argv[0], argv, environ);
+		static char *argv[] = { AUTORANDR_PATH, "--change", "--default", "default", NULL};
+		if (execve(argv[0], argv, environ) == -1) {
+        	int errsv = errno;
+			fprintf(stderr, "Error executing file: %s\n", strerror(errsv));
+			exit(errsv);
+        }
+
 		exit(127);
 	} else {
 		waitpid(pid, 0, 0);
@@ -147,10 +158,10 @@ int main(int argc, char **argv)
 			break;
 		}
 
-		// ar_log("Event type: %" PRIu8 "\n", evt->response_type);
-		// ar_log("screen change masked: %" PRIu8 "\n",
-		//       evt->response_type &
-		//       XCB_RANDR_NOTIFY_MASK_SCREEN_CHANGE);
+		ar_log("Event type: %" PRIu8 "\n", evt->response_type);
+		ar_log("screen change masked: %" PRIu8 "\n",
+		      evt->response_type &
+		       XCB_RANDR_NOTIFY_MASK_SCREEN_CHANGE);
 
 		if (evt->response_type &
 		    XCB_RANDR_NOTIFY_MASK_SCREEN_CHANGE) {

--- a/contrib/autorandr_launcher/autorandr_launcher.c
+++ b/contrib/autorandr_launcher/autorandr_launcher.c
@@ -150,14 +150,9 @@ int main(int argc, char **argv)
 
 	xcb_timestamp_t last_timestamp = (xcb_timestamp_t) 0;
 	time_t last_time = time(NULL);
-	while (1) {
-
-		ar_log("Waiting for event\n");
-		xcb_generic_event_t *evt = xcb_wait_for_event(c);
-		if (!evt) {
-			break;
-		}
-
+	ar_log("Waiting for event\n");
+	xcb_generic_event_t *evt;
+	while ( (evt = xcb_wait_for_event(c)) ) {
 		ar_log("Event type: %" PRIu8 "\n", evt->response_type);
 		ar_log("screen change masked: %" PRIu8 "\n",
 		      evt->response_type &

--- a/contrib/autorandr_launcher/makefile
+++ b/contrib/autorandr_launcher/makefile
@@ -1,0 +1,53 @@
+CFLAGS  = -pipe \
+	-o2 \
+	-Wstrict-overflow=5 -fstack-protector-all \
+	-W -Wall -Wextra \
+	-Wbad-function-cast \
+	-Wcast-align \
+	-Wcast-qual \
+	-Wconversion \
+	-Wfloat-equal \
+	-Wformat-y2k \
+	-Winit-self \
+	-Winline \
+	-Winvalid-pch \
+	-Wmissing-declarations \
+	-Wmissing-field-initializers \
+	-Wmissing-format-attribute \
+	-Wmissing-include-dirs \
+	-Wmissing-noreturn \
+	-Wmissing-prototypes \
+	-Wnested-externs \
+	-Wnormalized=nfc \
+	-Wold-style-definition \
+	-Woverlength-strings \
+	-Wpacked \
+	-Wpadded \
+	-Wpointer-arith \
+	-Wredundant-decls \
+	-Wshadow \
+	-Wsign-compare \
+	-Wstack-protector \
+	-Wstrict-aliasing=2 \
+	-Wstrict-prototypes \
+	-Wundef \
+	-Wunsafe-loop-optimizations \
+	-Wvolatile-register-var \
+	-Wwrite-strings
+
+
+LAUNCHER_LDLIBS=$(shell pkg-config --libs pkg-config xcb xcb-randr 2>/dev/null)
+LAUNCHER_CFLAGS=$(shell pkg-config --cflags pkg-config xcb xcb-randr 2>/dev/null)
+USER_DEFS="-DAUTORANDR_PATH=\"$(shell which autorandr 2>/dev/null)\""
+#------------------------------------------------------------------------------
+.PHONY : all clean
+
+#------------------------------------------------------------------------------
+all : autorandr-launcher
+
+autorandr-launcher: autorandr_launcher.c
+	$(CC) $(CFLAGS) $(LAUNCHER_CFLAGS) $(USER_DEFS) -o $@ $+ $(LAUNCHER_LDLIBS)
+
+#------------------------------------------------------------------------------
+clean :
+	$(RM) autorandr-launcher *.o


### PR DESCRIPTION
Hi, this PR adds some improvement to the code;

-  adds the possibility of the user compiling it locally (with makefile), and using its local autorandr path, It defines a macro that the makefile can overwrite for a local Path.
- Also changes ar_launch  to fit in the new C standards, and ar_log to use __attribute__ 
- Adds a check for the return of the execution, we never knew if it was running fine without this check

**The internal makefile can be a readme explaining the process, it is up to the owner to define the best**

[UPDATE]
In fact, since it was assuming that the path would be always the "/usr/bin", but if for any reason it was different. Let's suppose that 
`DESTDIR=~/ PREFIX=.local/ make install TARGETS='autorandr launcher'` 
So I added also in the general makefile to use the user inputs.


### The launcher is an alternative to the "udev/systemd setup" that is more stable for some users
The assumption of the PATH, combined with no error checking when executed could be the root cause of why udev/systemd is more stable for some user 

Closes #209 

