### PR TITLE
Direct --match-edid renaming of output messages to stderr

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -735,7 +735,7 @@ def update_profiles_edid(profiles, config):
                 if profile_config[c].fingerprint != fingerprint or c == fp_map[fingerprint]:
                     continue
 
-                print("%s: renaming display %s to %s" % (p, c, fp_map[fingerprint]))
+                print("%s: renaming display %s to %s" % (p, c, fp_map[fingerprint]), file=sys.stderr)
 
                 tmp_disp = profile_config[c]
 


### PR DESCRIPTION
This change helps scripts that consume autorandr output to only deal with profile names. My particular concern is with the output from 'autorandr --match-edid --detected'. With this change, only the detected profiles will go to another script. Command line users can still see the relevant messages if they have concerns about which port is in use.