### PR TITLE
Fix autorandr-kde.desktop PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ install_autostart_config:
 
 ifneq ($(PREFIX),/usr/)
 	sed -i -re 's#/usr/bin/autorandr#$(subst #,\#,${PREFIX})/bin/autorandr#g' ${DESTDIR}/${XDG_AUTOSTART_DIR}/autorandr.desktop
+	sed -i -re 's#/usr/bin/autorandr#$(subst #,\#,${PREFIX})/bin/autorandr#g' ${DESTDIR}/${XDG_AUTOSTART_DIR}/autorandr-kde.desktop
 endif
 
 uninstall_autostart_config:


### PR DESCRIPTION
The `make autostart_config` was correcting the `autorandr.desktop` file, but not the `autorandr-kde.desktop` file.