### PR TITLE
fix: remove literal backslashes in edid regex

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -232,7 +232,7 @@ class XrandrOutput(object):
             CRTC:\s*(?P<crtc>[0-9]) |                                                   # CRTC value
             Transform: (?P<transform>(?:[\-0-9\. ]+\s+){3}) |                           # Transformation matrix
                       filter:\s+(?P<filter>bilinear|nearest) |                          # Transformation filter
-            EDID: (?P<edid>\s*?(?:\\n\\t\\t[0-9a-f]+)+) |                               # EDID of the output
+            EDID: (?P<edid>\s*?(?:\n\t\t[0-9a-f]+)+) |                                  # EDID of the output
             """ + XRANDR_PROPERTIES_REGEXP + r""" |                                     # Properties to include in the profile
             (?![0-9])[^:\s][^:\n]+:.*(?:\s\t[\t ].+)*                                   # Other properties
         ))+

--- a/contrib/autorandr_launcher/.gitignore
+++ b/contrib/autorandr_launcher/.gitignore
@@ -1,0 +1,1 @@
+/autorandr-launcher


### PR DESCRIPTION
This fixes edid detection by searching for a newline followed by two tabs, instead of the literal string '\n\t\t'
