### PR TITLE
feat(autorandr_launcher)!: Search PATH for autorandr executable by default

### DIFF
--- a/contrib/autorandr_launcher/autorandr_launcher.c
+++ b/contrib/autorandr_launcher/autorandr_launcher.c
@@ -15,12 +15,11 @@
 #include <string.h>
 
 #ifndef AUTORANDR_PATH
-#define AUTORANDR_PATH "/usr/bin/autorandr"
+#define AUTORANDR_PATH "autorandr"
 #endif
 
 // indent -kr -i8
 static int VERBOSE = 0;
-extern char **environ;
 
 static void sigterm_handler(int signum)
 {
@@ -48,7 +47,7 @@ static int ar_launch(void)
 
 	pid_t pid = fork();
 	if (pid == 0) {
-		if (execve(argv[0], comm, environ) == -1) {
+		if (execvp(argv[0], comm) == -1) {
         	int errsv = errno;
 			fprintf(stderr, "Error executing file: %s\n", strerror(errsv));
 			exit(errsv);

--- a/contrib/autorandr_launcher/makefile
+++ b/contrib/autorandr_launcher/makefile
@@ -38,15 +38,25 @@ CFLAGS  = -pipe \
 
 LAUNCHER_LDLIBS=$(shell pkg-config --libs pkg-config xcb xcb-randr 2>/dev/null)
 LAUNCHER_CFLAGS=$(shell pkg-config --cflags pkg-config xcb xcb-randr 2>/dev/null)
-USER_DEFS="-DAUTORANDR_PATH=\"$(shell which autorandr 2>/dev/null)\""
 #------------------------------------------------------------------------------
 .PHONY : all clean
 
 #------------------------------------------------------------------------------
 all : autorandr-launcher
 
+# pass the following argument to make to override the default path to autorandr: AUTORANDR_PATH=/somepath/autorandr
+AUTORANDR_PATH=
+ifneq ($(AUTORANDR_PATH),)
+override AUTORANDR_PATH := -DAUTORANDR_PATH=\"$(AUTORANDR_PATH)\"
+endif
+
+USER_DEFS=
+ifneq ($(USER_DEFS),)
+$(warning "USER_DEFS is deprecated, use AUTORANDR_PATH instead")
+endif
+
 autorandr-launcher: autorandr_launcher.c
-	$(CC) $(CFLAGS) $(LAUNCHER_CFLAGS) $(USER_DEFS) -o $@ $+ $(LAUNCHER_LDLIBS)
+	$(CC) $(CFLAGS) $(LAUNCHER_CFLAGS) $(AUTORANDR_PATH) -o $@ $+ $(LAUNCHER_LDLIBS)
 
 #------------------------------------------------------------------------------
 clean :


### PR DESCRIPTION
- change execve to execvp, which seaches PATH for the executable if it
doesn't contain a slash.
- change default AUTORANDR_PATH to "autorandr" (instead of
/usr/bin/autorandr)
- Change makefile's cryptic USER_DEFS to AUTORANDR_PATH variable
- Allow change of hardcoded path (or executable name!) by `make
AUTORANDR_PATH=/somepath/autorandr`
- Add warning for any users of the old USER_DEFS
