### PR TITLE
Ignore processes with wrong XAUTHORITY file

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -1344,6 +1344,11 @@ def dispatch_call_to_sessions(argv):
             backup_candidates[display] = process_environ
             continue
 
+        if not os.path.exists(process_environ["XAUTHORITY"]):
+            # The XAUTHORITY may not be updated in tmux processes when the user re-login
+            backup_candidates[display] = process_environ
+            continue
+
         if display not in X11_displays_done:
             try:
                 pwent = pwd.getpwuid(uid)


### PR DESCRIPTION
This commit adds a check to see if the XAUTHORITY file exists for a given display. 
If it doesn't, the process environment is added to the backup candidates and the loop continues.
 This is particularly useful for tmux processes when the user re-logs in, as the XAUTHORITY may not be updated.