### PR TITLE
Minor updates to bash_completion/autorandr

### DIFF
--- a/contrib/bash_completion/autorandr
+++ b/contrib/bash_completion/autorandr
@@ -9,8 +9,7 @@ _autorandr ()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-	opts="-h -c -s -r -l -d"
-	lopts="--help --change --cycle --save --remove --load --list --default --force --fingerprint  --match-edid --config --dry-run"
+	lopts="--change  --config  --current  --cycle  --default  --dry-run --fingerprint   --force  --help  --list  --load  --match-edid  --remove  --save"
 
 	# find system-level autorandr dirs
 	OIFS="$IFS"
@@ -42,18 +41,18 @@ _autorandr ()
 			return 0
 			;;
 		-*)
-			COMPREPLY=( $( compgen -W "${opts} ${lopts}" -- $cur ) )
+			COMPREPLY=( $( compgen -W "${lopts}" -- $cur ) )
 			return 0
 			;;
 		*)
 			if [ $COMP_CWORD -eq 1 ]; then
-				COMPREPLY=( $( compgen -W "${opts} ${lopts}" -- $cur ) )
+				COMPREPLY=( $( compgen -W "${lopts}" -- $cur ) )
 			fi
 			;;
 		esac
 
 	case "${prev}" in
-		-r|--remove|-l|--load|-d|--default)
+		-r|--remove|-l|--load|-d|--default|--save|-s)
 			COMPREPLY=( $( compgen -W "${prfls}" -- $cur ) )
 			return 0
 			;;


### PR DESCRIPTION
1. Removes short options from being autocompleted:
   * With autocompletion there is not that much need for keeping these less descriptive option as autocompleted;
   * They are one key-stroke long and you would still have to type at least one more keystroke.
   * Since short options use only one dash, they get in the way of completing the second dash for all the other options, forcing the user to type at least two dashes.

2. Adds --save|-s as an option to be completed with profile names.

Note: short options are still considered for profile name autocompletion.