### PR TITLE
fix: prefer serial no over serial text

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -379,7 +379,7 @@ class XrandrOutput(object):
                         buffer = timing_bytes[5:]
                         buffer = buffer.partition(b'\x0a')[0]
                         serial_text = buffer.decode('cp437')
-            self.serial = serial_text if serial_text else "0x{:x}".format(serial_no) if serial_no != 0 else None
+            self.serial = "0x{:x}".format(serial_no) if serial_no != 0 else serial_text if serial_text else None
 
     def set_ignored_options(self, options):
         "Set a list of xrandr options that are never used (neither when comparing configurations nor when applying them)"


### PR DESCRIPTION
Fixes #406 

The current serial based matching behaviour was specified in d9b1953. The commit message specifies that matching on serial number should be preferred over constructing a text based fingerprint from timing information (which matches legacy behaviour of autorandr).

However, the actual code has the conditional reversed, which means that the new behaviour was never employed. This means the matching behaviour is still suffering from the previous issues like changing edid data when the same monitor switches interface etc (DP to HDMI for example) or the port on the gpu changes and now has different capabilities etc.

This commit switches the conditional around, using serial no. if it is not zero, using the legacy serial_text if available and otherwise setting serial to None