### PR TITLE
Fix: snapd-desktop-integration bug

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -1281,6 +1281,9 @@ def dispatch_call_to_sessions(argv):
             os.setresuid(pwent.pw_uid, pwent.pw_uid, pwent.pw_uid)
             os.chdir(pwent.pw_dir)
             os.environ.clear()
+            # fixes a bug with snapd-desktop-integration changing config directories
+            if process_environ.get("SNAP_NAME") == "snapd-desktop-integration":
+                process_environ = {k: v for k, v in process_environ.items() if k not in {'XDG_CONFIG_HOME', 'LD_PRELOAD', 'HOME'}}
             os.environ.update(process_environ)
             if sys.executable != "" and sys.executable != None:
                 os.execl(sys.executable, sys.executable, autorandr_binary, *argv[1:])


### PR DESCRIPTION
Fixes https://github.com/phillipberndt/autorandr/issues/379

On Ubuntu at least, the snapd-desktop-integration snap changes the entries in the environ file found by autorandr when running as a service, and this results in autorandr not finding the profile entries. To fix this, I've checked SNAP_NAME to see if the snapd-desktop-integration appears to be running, and if it is, I remove the three problematic environ entries from `process_environ`. Errors are thrown if any of these three entries are left in, and no errors appear to be given in my testing (restarting the service and plugging in/unplugging monitors) with them removed. 