### PR TITLE
Fix profile detection when lid state differs from save time

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -148,7 +148,7 @@ class Version(object):
         return self >= other and not (self == other)
 
 def is_closed_lid(output):
-    if not re.match(r'(eDP(-?[0-9]\+)*|LVDS(-?[0-9]\+)*)', output):
+    if not re.match(r'(eDP(-?[0-9]+)*|LVDS(-?[0-9]+)*)', output):
         return False
     lids = glob.glob("/proc/acpi/button/lid/*/state")
     if len(lids) == 1:
@@ -765,11 +765,15 @@ def find_profiles(current_config, profiles):
             if name not in current_config or not output.fingerprint_equals(current_config[name]):
                 matches = False
                 break
-        if not matches or any((name not in config.keys() for name in current_config.keys() if current_config[name].fingerprint)):
+        if not matches or any((name not in config.keys() for name in current_config.keys()
+                               if current_config[name].fingerprint and not re.match(r'(eDP|LVDS)', name))):
             continue
         if matches:
-            closeness = max(match_asterisk(output.edid, current_config[name].edid), match_asterisk(
-                current_config[name].edid, output.edid))
+            closeness = 1
+            for name, output in config.items():
+                if output.edid and name in current_config and current_config[name].edid:
+                    closeness = min(closeness, max(match_asterisk(output.edid, current_config[name].edid),
+                        match_asterisk(current_config[name].edid, output.edid)))
             detected_profiles.append((closeness, profile_name))
     detected_profiles = [o[1] for o in sorted(detected_profiles, key=lambda x: -x[0])]
     return detected_profiles


### PR DESCRIPTION
## Summary

- **eDP/LVDS lid exemption in `find_profiles`**: Profiles saved with the laptop lid closed don't include the eDP/LVDS output's EDID in the setup file. When the lid is later opened, `find_profiles` rejects the profile because the eDP output has a fingerprint but isn't in the profile config. Fix: exempt eDP/LVDS outputs from the completeness check, since they may not have been present at save time due to a closed lid.

- **Closeness calculation bug**: The closeness score used stale loop variables (`output`, `name`) left over from the preceding `for` loop iteration, rather than computing across all profile outputs. This could produce incorrect rankings or crash on profiles with `edid=None` outputs. Fix: iterate all config items and use `min` closeness across outputs with valid EDIDs.

- **`is_closed_lid` regex**: `\+` (literal plus) should be `+` (one-or-more quantifier) for matching output names like `eDP-1`. Worked by accident because the `*` quantifier allowed zero matches of the group, but was incorrect.

## Test plan

- [ ] Save a profile with the laptop lid closed (e.g. docked with external monitor only)
- [ ] Open the lid and run `autorandr` — the docked profile should be detected
- [ ] Verify that less-specific profiles (e.g. laptop-only `default`) are NOT detected when external monitors are connected
- [ ] Verify profiles with EDID wildcards still rank correctly by closeness