### PR TITLE
Accept comma decimal in mode rates (locale-tolerant parsing)

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -240,7 +240,7 @@ class XrandrOutput(object):
         (?P<modes>(?:
             (?P<mode_name>\S+).+?\*current.*\s+                                         # Interesting (current) resolution:
              h:\s+width\s+(?P<mode_width>[0-9]+).+\s+                                   # Extract rate
-             v:\s+height\s+(?P<mode_height>[0-9]+).+clock\s+(?P<rate>[0-9\.]+)Hz\s* |
+             v:\s+height\s+(?P<mode_height>[0-9]+).+clock\s+(?P<rate>[0-9\.,]+)Hz\s* |
             \S+(?:(?!\*current).)+\s+h:.+\s+v:.+\s*                                     # Other resolutions
         )*)
     """
@@ -248,7 +248,7 @@ class XrandrOutput(object):
     XRANDR_OUTPUT_MODES_REGEXP = r"""(?x)
         (?P<name>\S+).+?(?P<preferred>\+preferred)?\s+
          h:\s+width\s+(?P<width>[0-9]+).+\s+
-         v:\s+height\s+(?P<height>[0-9]+).+clock\s+(?P<rate>[0-9\.]+)Hz\s* |
+         v:\s+height\s+(?P<height>[0-9]+).+clock\s+(?P<rate>[0-9\.,]+)Hz\s* |
     """
 
     XRANDR_13_DEFAULTS = {
@@ -494,7 +494,9 @@ class XrandrOutput(object):
             if match["crtc"]:
                 options["crtc"] = match["crtc"]
             if match["rate"]:
-                options["rate"] = match["rate"]
+                # Normalize comma decimal separator (locales like de_DE use ',')
+                # so downstream xrandr --rate calls always see a '.' decimal.
+                options["rate"] = match["rate"].replace(",", ".")
             for prop in [re.sub(r"\W+", "_", p.lower()) for p in properties]:
                 if match[prop]:
                     options["x-prop-" + prop] = match[prop]

--- a/autorandr.py
+++ b/autorandr.py
@@ -845,6 +845,12 @@ def call_and_retry(*args, **kwargs):
     waits a second and then retries once. This mitigates #47,
     a timing issue with some drivers.
     """
+    # Force C locale for xrandr subprocess: under locales like de_DE,
+    # xrandr's float parser rejects '.' decimals (e.g. --gamma 1.0,
+    # --rate 165.00) and only accepts ',' as the decimal separator.
+    # See #424.
+    if "env" not in kwargs:
+        kwargs["env"] = {**os.environ, "LC_ALL": "C"}
     if kwargs.pop("dry_run", False):
         for arg in args[0]:
             print(shlex.quote(arg), end=" ")


### PR DESCRIPTION
Fixes #424.

Under locales that use a comma as decimal separator (de_DE, fr_FR, sv_SE, ...) `xrandr --verbose` prints mode rates like `90,00Hz`. The regex `(?P<rate>[0-9\.]+)Hz` does not match, and parsing fails entirely.

Setting `Environment=LC_ALL=C` in the systemd unit does not help because `fork_child_autorandr` clears the environment and inherits the user's session locale.

This patch:
1. Extends the two `rate` patterns to accept `[0-9\.,]+`.
2. Normalizes captured rates with `.replace(",", ".")` so that the value stored in profile config and passed to `xrandr --rate` stays in the canonical form.

Tested under `LANG=de_DE.UTF-8 LC_NUMERIC=de_DE.UTF-8` — `autorandr --detected` now exits 0 instead of failing with "12585 bytes left unmatched".