### PR TITLE
fix: adjust transision fb size to fit interim layout

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -932,6 +932,23 @@ def apply_configuration(new_configuration, current_configuration, dry_run=False)
         # Failed to obtain frame-buffer size. Doesn't matter, xrandr will choose for the user.
         fb_args = []
 
+    # While outputs are being disabled/repositioned below, any output that hasn't been
+    # touched by the current xrandr call yet is still sitting at its *current* geometry.
+    # If we already constrained the framebuffer to the final (possibly smaller) target
+    # size at this point, such an untouched output can stick out of the framebuffer and
+    # make the whole call fail with "screen not large enough for output ...". So use a
+    # framebuffer that is large enough for both the current and the new layout while
+    # transitioning, and only shrink it down to the final size once every output has
+    # reached its new position (see the "Adjust the frame buffer to match" step below).
+    try:
+        current_fb_dimensions = get_fb_dimensions(current_configuration)
+        interim_fb_args = ["--fb", "%dx%d" % (
+            max(fb_dimensions[0], current_fb_dimensions[0]),
+            max(fb_dimensions[1], current_fb_dimensions[1]),
+        )]
+    except:
+        interim_fb_args = fb_args
+
     auxiliary_changes_pre = []
     disable_outputs = []
     enable_outputs = []
@@ -983,7 +1000,8 @@ def apply_configuration(new_configuration, current_configuration, dry_run=False)
     # Starting here, fix the frame buffer size
     # Do not do this earlier, as disabling scaling might temporarily make the framebuffer
     # dimensions larger than they will finally be.
-    base_argv += fb_args
+    # Use the interim (safe) size here rather than the final target size -- see above.
+    base_argv += interim_fb_args
 
     # Disable unused outputs, but make sure that there always is at least one active screen
     disable_keep = 0 if remain_active_count else 1
@@ -1019,8 +1037,10 @@ def apply_configuration(new_configuration, current_configuration, dry_run=False)
             raise AutorandrException("Command failed: %s" % " ".join(map(shlex.quote, argv)))
 
     # Adjust the frame buffer to match (see #319)
+    # Now that every output has reached its final position, it is safe to shrink the
+    # framebuffer down from the interim (safe) size to the real target size.
     if fb_args:
-        argv = base_argv
+        argv = ["xrandr"] + fb_args
         if call_and_retry(argv, dry_run=dry_run) != 0:
             raise AutorandrException("Command failed: %s" % " ".join(map(shlex.quote, argv)))
 


### PR DESCRIPTION
This PR fixes a problem I have experienced with my 4 monitor setup.

## Orignal error reported by autorandr:
```
 ./autorandr -l broken-load
  Failed to apply profile 'broken-load' (line 1019):
    Command failed: xrandr --fb 7040x2880 --output DP-1.3 --crtc 3 --gamma 1.0:1.0:1.0 --mode 2560x1440 --pos 0x0 --rate 59.95 --reflect normal --rotate normal --set non-desktop 0
  --output DP-1.2 --crtc 0 --gamma 1.0:1.0:1.0 --mode 2560x1440 --pos 0x1440 --primary --rate 59.95 --reflect normal --rotate normal --set non-desktop 0 (line 1019)
```

## Analisys
1. Before I run autorandr -l broken-load, my monitors are in some other layout. In particular DP-0 sits at position 7680,0. Since it's 1920 wide, the screen needs to be at least 9600 px wide to hold it.
2. autorandr wants to end up with a 7040x2880 framebuffer. But because some drivers choke if you enable more than two outputs in one xrandr call, it splits the work into multiple calls, first it touches DP-1.3+DP-1.2, then later DP-1.1+DP-0.
3. The bug: it puts --fb 7040x2880 (the final size) on that first call, the one that only touches DP-1.3 and DP-1.2. DP-0 isn't mentioned in that call at all, so it hasn't moved,  it's still sitting at 7680,0 from step 1.
4. So that first call is effectively saying: "Shrink the canvas to 7040 wide, while DP-0 is still parked at x=7680 (needs 9600)." DP-0 now hangs off the right edge of a too-small canvas. X refuses: "screen not large enough for output DP-0".

## Proposed Fix
While disabling/repositioning outputs, use an interim framebuffer size that is large enough for both the current and the new layout (the per-dimension max of the two), instead of the final target size. Only shrink to the real target size in the closing "adjust the frame buffer to match" step (see #319), once every output has reached its new position.

## Considered Fix
Alternative would be to add a flag to disable monitor splitting into groups of 2 and perform entire reconfiguration in one step.