### PR TITLE
Skip processes that vanish while scanning /proc in dispatch_call_to_sessions

### DIFF
--- a/autorandr.py
+++ b/autorandr.py
@@ -1357,13 +1357,22 @@ def dispatch_call_to_sessions(argv):
         environ_file = os.path.join(directory, "environ")
         if not os.path.isfile(environ_file):
             continue
-        uid = os.stat(environ_file).st_uid
+        try:
+            uid = os.stat(environ_file).st_uid
 
-        if uid < uid_min:
+            if uid < uid_min:
+                continue
+
+            environ_data = open(environ_file, 'rb').read()
+        except OSError:
+            # The process is a zombie or vanished between listdir() and
+            # open(); reading /proc/<pid>/environ then raises
+            # ProcessLookupError, FileNotFoundError or PermissionError
+            # (all subclasses of OSError). Skip such processes.
             continue
 
         process_environ = {}
-        for environ_entry in open(environ_file, 'rb').read().split(b"\0"):
+        for environ_entry in environ_data.split(b"\0"):
             try:
                 environ_entry = environ_entry.decode("ascii")
             except UnicodeDecodeError:


### PR DESCRIPTION
When dispatch_call_to_sessions() iterates over /proc, a process can be a zombie or terminate between listdir() and the stat()/open() of its environ file. Reading /proc/<pid>/environ of a zombie raises ProcessLookupError; short-lived processes can also trigger FileNotFoundError or PermissionError. autorandr then aborts with a traceback instead of dispatching the call to the remaining sessions:

  File ".../autorandr.py", line 1313, in dispatch_call_to_sessions
    for environ_entry in open(environ_file, 'rb').read().split(b"\0"):
  ProcessLookupError: [Errno 3] No such process: '/proc/4937/environ'

Any zombie with uid >= AUTORANDR_UID_MIN triggers this: its environ file still exists and os.path.isfile() succeeds, but reading it fails with ESRCH. In our case the zombie was a sandbox helper left behind by a desktop application; it lived for days, so every batch invocation (systemd/udev hotplug service) failed with exit 1 and automatic display switching was completely broken.

Fix: wrap the os.stat() and the environ read in a try/except OSError (the common base class of all three exceptions) and skip such processes, continuing with the rest of the /proc scan.

Verified on NixOS with autorandr 1.15 (this code region is unchanged on master): with 7 live defunct processes present, the batch service failed on every run; with this change applied it exits 0 and dispatches the call to the X session as expected.

AI authorship disclosure: this patch was written by Claude (Anthropic's "Fable" model) under the direction of the submitter, who reviewed and verified it on the affected system. The pull request is submitted and maintained by a human.

Fixes #429